### PR TITLE
fix README.md link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ https://www.r-project.org/ for details.
 
 Then install RattleNG for your operating system as detailed in the
 installers <a
-href="https://github.com/gjwgit/rattleng/blob/dev/installers/README.md>README</a>.
+href="https://github.com/gjwgit/rattleng/blob/dev/installers/README.md">README</a>.
 
 Then:
 
@@ -98,7 +98,7 @@ Currently implemented features:
 ## Building RattleNG from Source
 
 Ensure you have R installed, as described in the installer <a
-href="https://github.com/gjwgit/rattleng/blob/dev/installers/README.md>README</a>.
+href="https://github.com/gjwgit/rattleng/blob/dev/installers/README.md">README</a>.
 
 Install Flutter as describe in the <a
 href="https://docs.flutter.dev/get-started/install">Flutter Install


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- fix the README link typo in README.md


## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [ ] Changes adhere to the style and coding guideline
- [x] No confidential information
- [ ] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [x] Chrome
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
- [ ] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
