### PR TITLE
zy/52 DATASET: Allow input of dataset in text bar and loaded when Enter is pressed

### DIFF
--- a/lib/constants/app.dart
+++ b/lib/constants/app.dart
@@ -44,6 +44,10 @@ const String welcomeMsgFile = '$assetsPath/markdown/welcome.md';
 
 const String scriptIntroFile = '$assetsPath/markdown/script_intro.md';
 
+/// File name of demo file (weather.csv).
+
+const String weatherDemoFile = 'rattle::weather';
+
 // proportion of window that display panel takes
 // const double displayRatio = 0.75;
 

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -73,7 +73,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
     String content = '';
     String title = '';
 
-    if (path == 'rattle::weather' || path.endsWith('.csv')) {
+    if (path == weatherDemoFile || path.endsWith('.csv')) {
       content = rExtractGlimpse(stdout);
       title = '''
 
@@ -104,7 +104,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
       );
     }
 
-    if (path == 'rattle::weather' || path.endsWith('.csv')) {
+    if (path == weatherDemoFile || path.endsWith('.csv')) {
       Map<String, Role> currentRoles = ref.read(rolesProvider);
 
       // Extract variable information from the R console.

--- a/lib/features/dataset/popup.dart
+++ b/lib/features/dataset/popup.dart
@@ -30,6 +30,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:rattle/constants/app.dart';
 import 'package:rattle/constants/status.dart';
 import 'package:rattle/features/dataset/select_file.dart';
 import 'package:rattle/providers/dataset_loaded.dart';
@@ -129,7 +130,7 @@ class DatasetPopup extends ConsumerWidget {
                 onPressed: () {
                   // TODO 20231101 gjw DEFINE setPath()
 
-                  ref.read(pathProvider.notifier).state = 'rattle::weather';
+                  ref.read(pathProvider.notifier).state = weatherDemoFile;
 
                   // TODO 20240714 gjw HOW TO GET THE weather.csv FROM ASSETS
                   // ref.read(pathProvider.notifier).state =

--- a/lib/features/dataset/text_field.dart
+++ b/lib/features/dataset/text_field.dart
@@ -27,7 +27,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:rattle/constants/keys.dart';
+import 'package:rattle/constants/status.dart';
+import 'package:rattle/features/dataset/popup.dart';
 import 'package:rattle/providers/path.dart';
+import 'package:rattle/r/load_dataset.dart';
+import 'package:rattle/utils/set_status.dart';
 import 'package:rattle/widgets/delayed_tooltip.dart';
 
 class DatasetTextField extends ConsumerWidget {
@@ -68,6 +72,12 @@ class DatasetTextField extends ConsumerWidget {
 
           onChanged: (newPath) {
             ref.watch(pathProvider.notifier).state = newPath;
+          },
+          onSubmitted: (newPath) {
+            rLoadDataset(context, ref);
+            setStatus(ref, statusChooseVariableRoles);
+
+            datasetLoadedUpdate(ref);
           },
 
           // For an empty value we show a helpful message.

--- a/lib/r/load_dataset.dart
+++ b/lib/r/load_dataset.dart
@@ -29,6 +29,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:rattle/constants/app.dart';
 import 'package:rattle/providers/path.dart';
 import 'package:rattle/r/source.dart';
 
@@ -52,7 +53,7 @@ void rLoadDataset(BuildContext context, WidgetRef ref) {
 
   debugPrint("R LOAD DATASET:\t'$path'");
 
-  if (path == '' || path == 'rattle::weather') {
+  if (path == '' || path == weatherDemoFile) {
     // The default, when we get here and no path has been specified yet, is to
     // load the weather dataset as the demo dataset from R's rattle package.
 

--- a/lib/r/load_dataset.dart
+++ b/lib/r/load_dataset.dart
@@ -67,6 +67,20 @@ void rLoadDataset(BuildContext context, WidgetRef ref) {
   } else {
     debugPrint('LOAD_DATASET: PATH NOT RECOGNISED -> ABORT: $path.');
 
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('PATH NOT RECOGNISED'),
+        content: const Text('Unable to load dataset'),
+        actions: <Widget>[
+          ElevatedButton(
+            child: const Text('OK'),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ],
+      ),
+    );
+
     return;
   }
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- DATASET: Allow input of dataset in text bar and loaded when Enter is pressed

- Link to associated issue: #52 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
