### PR TITLE
zy/227 SCRIPT: Save adds an extra '.R'

### DIFF
--- a/lib/tabs/script/save_button.dart
+++ b/lib/tabs/script/save_button.dart
@@ -140,8 +140,9 @@ class ScriptSaveButton extends ConsumerWidget {
     file.writeAsString(script);
 
     // Show a confirmation message.
+    final filePath = file.absolute.path;
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('File saved as $fileName.R')),
+      SnackBar(content: Text('File saved as $fileName at $filePath')),
     );
   }
 }


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- SCRIPT: Save adds an extra '.R'

- Link to associated issue: #227

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
