### PR TITLE
Zy/228 image popup window display

### DIFF
--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -39,7 +39,6 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'package:rattle/constants/sunken_box_decoration.dart';
 import 'package:rattle/utils/select_file.dart';
-import 'package:rattle/utils/show_under_construction.dart';
 import 'package:rattle/utils/word_wrap.dart';
 
 class ImagePage extends StatelessWidget {
@@ -120,7 +119,54 @@ class ImagePage extends StatelessWidget {
                           color: Colors.blue,
                         ),
                         onPressed: () {
-                          showUnderConstruction(context);
+                          showGeneralDialog(
+                            context: context,
+                            pageBuilder:
+                                (context, animation, secondaryAnimation) {
+                              return Center(
+                                child: Material(
+                                  type: MaterialType.transparency,
+                                  child: Stack(
+                                    children: [
+                                      Container(
+                                        width:
+                                            MediaQuery.of(context).size.width *
+                                                0.9,
+                                        height:
+                                            MediaQuery.of(context).size.height *
+                                                0.9,
+                                        padding: const EdgeInsets.all(16.0),
+                                        color: Colors.white,
+                                        child: InteractiveViewer(
+                                          maxScale: 5,
+                                          child: SvgPicture.memory(bytes),
+                                        ),
+                                      ),
+                                      Positioned(
+                                        top: 10,
+                                        right: 10,
+                                        child: GestureDetector(
+                                          onTap: () {
+                                            Navigator.of(context).pop();
+                                          },
+                                          child: const Icon(
+                                            Icons.close,
+                                            color: Colors.grey,
+                                            size: 30,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              );
+                            },
+                            barrierDismissible: true,
+                            barrierLabel: MaterialLocalizations.of(context)
+                                .modalBarrierDismissLabel,
+                            transitionDuration:
+                                const Duration(milliseconds: 200),
+                          );
                         },
                         tooltip: 'Press here to view the plot\n'
                             'in a separate window.',

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- IMAGE PAGE: Add a new button to popup a window to display the image

- Link to associated issue: #228 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
