### PR TITLE
chore: Update flutter_pty dependency to fix Windows script issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ toward a 6.3 release.
 + Refactor dataset feature [6.2.3 20240715 gjw]
 + Initial R code and integration of exploration plots [6.2.2 20240715 gjw]
 + Add EXPORT to ImagePage() [6.2.1 20240712 gjw]
++ Fix Windows R console connectivity issue [20240809 Lutra-Fs]
 
 ## 6.2 Dataset Roles, Display Pages.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,11 @@ dependencies:
   file_picker: ^8.0.6
   flutter_gen: ^5.3.1
   flutter_markdown: ^0.7.1
-  flutter_pty: ^0.4.0
+  # flutter_pty: ^0.4.0
+  flutter_pty:
+    git:
+      url: https://github.com/KitasaitamalBlues/flutter_pty.git
+      ref: main
   flutter_riverpod: ^2.4.4
   flutter_svg: ^2.0.7
   intl: ^0.19.0
@@ -35,6 +39,7 @@ dependencies:
   url_launcher: ^6.3.0
   window_manager: ^0.3.5
   xterm: ^4.0.0
+  
   
 dev_dependencies:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   file_picker: ^8.0.6
   flutter_gen: ^5.3.1
   flutter_markdown: ^0.7.1
-  # flutter_pty: ^0.4.0
+  # flutter_pty: ^4.0.0
   flutter_pty:
     git:
       url: https://github.com/KitasaitamalBlues/flutter_pty.git


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- This PR fix the issue which pacman cannot be installed on Windows Rattle by switching the `flutter-pty` upstream to [KitasaitamalBlues](https://github.com/KitasaitamalBlues)'s one. See this PR https://github.com/TerminalStudio/flutter_pty/pull/15 for details. Once this PR gets merged, we could switch back to the main repo.

- Closes #268

![image](https://github.com/user-attachments/assets/1fdc8dba-58af-4f9e-8861-50d2872836c6)
![image](https://github.com/user-attachments/assets/04b7a933-ca67-4747-a19c-e223f5db8143)

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted:
	warning - Unused import: 'package:rattle/r/start.dart' - lib\app.dart:36:8 - unused_import
warning - The value of the local variable 'stdout' isn't used - lib\features\visual\display.dart:53:12 - unused_local_variable
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [x] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
