### PR TITLE
zy/ 231 R SOURCE: Identify the current version and replace VERSION in R script templates

### DIFF
--- a/lib/r/source.dart
+++ b/lib/r/source.dart
@@ -30,6 +30,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:rattle/utils/get_ignored.dart';
 import 'package:rattle/utils/to_r_vector.dart';
 import 'package:universal_io/io.dart' show Platform;
@@ -121,13 +122,9 @@ void rSource(BuildContext context, WidgetRef ref, String script) async {
 
   // Populate the VERSION.
 
-  // PackageInfo info = await PackageInfo.fromPlatform();
-  // code = code.replaceAll('VERSION', info.version);
-  //
-  // TODO 20231102 gjw THIS FAILS FOR NOW AS REQUIRES A FUTURE SO FIX THE
-  // VERSION FOR NOW.
+  PackageInfo info = await PackageInfo.fromPlatform();
 
-  code = code.replaceAll('VERSION', '0.0.0');
+  code = code.replaceAll('VERSION', info.version);
 
   code = code.replaceAll('FILENAME', path);
 

--- a/lib/r/start.dart
+++ b/lib/r/start.dart
@@ -31,6 +31,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 import 'package:rattle/providers/pty.dart';
 //import 'package:rattle/providers/stdout.dart';
@@ -74,6 +75,8 @@ void rStart(BuildContext context, WidgetRef ref) async {
 
   const asset = 'assets/r/main.R';
   String code = await DefaultAssetBundle.of(context).loadString(asset);
+  PackageInfo info = await PackageInfo.fromPlatform();
+  code = code.replaceAll('VERSION', info.version);
 
   // 20240615 gjw Previously the code used File() to access the asset file which
   // worked fine in development but failed on a deployment. Thus I moved to the


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- R SOURCE: Identify the current version and replace VERSION in R script templates

- Link to associated issue: #231

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
