### PR TITLE
Fix Windows path conversion issue in rSource

### DIFF
--- a/lib/r/source.dart
+++ b/lib/r/source.dart
@@ -128,6 +128,12 @@ Future<void> rSource(BuildContext context, WidgetRef ref, String script) async {
 
   code = code.replaceAll('VERSION', info.version);
 
+  // Fix the path to the dataset.
+  // ensure that the Windows path has been correctly converted to a Unix path
+  // for R.
+  if (Platform.isWindows) {
+    path = path.replaceAll(r'\', '/');
+  }
   code = code.replaceAll('FILENAME', path);
 
   // TODO 20240630 gjw EVENTUALLY SELECTIVELY REPLACE


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fixes Path Delimiter issue when loading data on Windows, allowing datasets to be loaded using backslashes returned by the file-picker.

- Link to associated issue: #357

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
