### PR TITLE
fix the issue prevents Windows popup the svg

### DIFF
--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -144,15 +144,14 @@ class ImagePage extends StatelessWidget {
 
                           // Copy the original file to the temporary file.
 
-                          File originalFile = File(path);
-                          tempFile
-                              .writeAsBytesSync(originalFile.readAsBytesSync());
+                          File(path).copy(tempFile.path);
 
                           // Pop out a window to display the plot separate
                           // to the Rattle app.
 
                           Platform.isWindows
-                              ? Process.run('start', [tempFile.path])
+                              ? Process.run('start', [tempFile.path],
+                                  runInShell: true)
                               : Process.run('open', [tempFile.path]);
                         },
                       ),

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -151,7 +151,7 @@ class ImagePage extends StatelessWidget {
 
                           Platform.isWindows
                               ? Process.run('start', [tempFile.path],
-                                  runInShell: true)
+                                  runInShell: true,)
                               : Process.run('open', [tempFile.path]);
                         },
                       ),


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fixes issue that prevents Windows from displaying SVG popups by using the shell environment `runInShell: true`

- Link to associated issue: #228

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
