### PR TITLE
zy/204 IMAGE PAGE: When full screen the image should scale to take up the whole page

### DIFF
--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -178,17 +178,35 @@ class ImagePage extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: 5),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    mainAxisSize: MainAxisSize.max,
-                    children: [
-                      Expanded(
-                        child: InteractiveViewer(
-                          maxScale: 5,
-                          child: SvgPicture.memory(bytes),
+                  LayoutBuilder(
+                    builder: (context, constraints) {
+                      // The max available width from LayoutBuilder.
+                      final maxWidth = constraints.maxWidth;
+
+                      // Apply a bounded height to avoid infinite height error.
+                      final double maxHeight =
+                          MediaQuery.of(context).size.height * 0.8;
+
+                      return SizedBox(
+                        height: maxHeight,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          mainAxisSize: MainAxisSize.max,
+                          children: [
+                            Expanded(
+                              child: InteractiveViewer(
+                                maxScale: 5,
+                                child: SvgPicture.memory(
+                                  bytes,
+                                  width: maxWidth,
+                                  fit: BoxFit.contain,
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
-                      ),
-                    ],
+                      );
+                    },
                   ),
                 ],
               ),


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- IMAGE PAGE: When full screen the image should scale to take up the whole page

- Link to associated issue: #204 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
