### PR TITLE
kev/341_delete_helper_rename_util_functions

### DIFF
--- a/integration_test/dataset_reset_todo.dart
+++ b/integration_test/dataset_reset_todo.dart
@@ -38,7 +38,7 @@ import 'package:rattle/tabs/model.dart';
 import 'package:rattle/widgets/image_page.dart';
 
 import 'utils/delays.dart';
-import 'utils/navigate_to_tab.dart';
+import 'utils/navigate_to_feature.dart';
 import 'utils/navigate_to_page.dart';
 import 'utils/open_demo_dataset.dart';
 import 'utils/open_large_dataset.dart';
@@ -60,7 +60,7 @@ void main() {
         ModelTabs,
       );
 
-      await navigateToTab(tester, 'Tree', TreePanel);
+      await navigateToFeature(tester, 'Tree', TreePanel);
 
       await pressButton(tester, 'Build Decision Tree');
 
@@ -112,7 +112,7 @@ void main() {
         ModelTabs,
       );
 
-      await navigateToTab(tester, 'Tree', TreePanel);
+      await navigateToFeature(tester, 'Tree', TreePanel);
       // Find the TabPageSelector and check its page count.
       final tabPageSelectorFinder = find.byType(TabPageSelector);
       expect(tabPageSelectorFinder, findsOneWidget);
@@ -142,7 +142,7 @@ void main() {
       ModelTabs,
     );
 
-    await navigateToTab(tester, 'Tree', TreePanel);
+    await navigateToFeature(tester, 'Tree', TreePanel);
 
     await pressButton(tester, 'Build Decision Tree');
 
@@ -195,7 +195,7 @@ void main() {
       ModelTabs,
     );
 
-    await navigateToTab(tester, 'Tree', TreePanel);
+    await navigateToFeature(tester, 'Tree', TreePanel);
     // Find the TabPageSelector and check its page count.
     final tabPageSelectorFinder = find.byType(TabPageSelector);
     expect(tabPageSelectorFinder, findsOneWidget);

--- a/integration_test/explore_correlation_demo_test.dart
+++ b/integration_test/explore_correlation_demo_test.dart
@@ -32,13 +32,12 @@ import 'package:rattle/features/correlation/panel.dart';
 import 'package:rattle/main.dart' as app;
 
 import 'utils/delays.dart';
+import 'utils/navigate_to_feature.dart';
 import 'utils/navigate_to_tab.dart';
 import 'utils/open_demo_dataset.dart';
 import 'utils/press_button.dart';
 import 'utils/verify_page_content.dart';
 import 'utils/verify_text.dart';
-
-import 'helper.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -50,8 +49,8 @@ void main() {
       await tester.pump(pause);
 
       await openDemoDataset(tester);
-      await navigateToExploreTab(tester);
-      await navigateToTab(tester, 'Correlation', CorrelationPanel);
+      await navigateToTab(tester, 'Explore');
+      await navigateToFeature(tester, 'Correlation', CorrelationPanel);
       await pressButton(tester, 'Perform Correlation Analysis');
 
       // Verify the content of the page 1.

--- a/integration_test/explore_correlation_large_test.dart
+++ b/integration_test/explore_correlation_large_test.dart
@@ -31,8 +31,8 @@ import 'package:integration_test/integration_test.dart';
 import 'package:rattle/features/correlation/panel.dart';
 import 'package:rattle/main.dart' as app;
 
-import 'helper.dart';
 import 'utils/delays.dart';
+import 'utils/navigate_to_feature.dart';
 import 'utils/navigate_to_tab.dart';
 import 'utils/open_large_dataset.dart';
 import 'utils/press_button.dart';
@@ -49,8 +49,8 @@ void main() {
       await tester.pump(pause);
 
       await openLargeDataset(tester);
-      await navigateToExploreTab(tester);
-      await navigateToTab(tester, 'Correlation', CorrelationPanel);
+      await navigateToTab(tester, 'Explore');
+      await navigateToFeature(tester, 'Correlation', CorrelationPanel);
       await pressButton(tester, 'Perform Correlation Analysis');
 
       // Verify the content of the page 1.

--- a/integration_test/utils/navigate_to_feature.dart
+++ b/integration_test/utils/navigate_to_feature.dart
@@ -1,6 +1,6 @@
-/// Helper functions for integration tests.
+/// Navigate to a feature in the app.
 //
-// Time-stamp: <Tuesday 2024-09-03 09:05:26 +1000 Graham Williams>
+// Time-stamp: <Tuesday 2024-09-03 09:03:00 +1000 Graham Williams>
 //
 /// Copyright (C) 2023-2024, Togaware Pty Ltd
 ///
@@ -26,18 +26,17 @@
 library;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/material.dart';
 
-import 'package:rattle/tabs/explore.dart';
+Future<void> navigateToFeature(
+  WidgetTester tester,
+  String tabTitle,
+  Type panelType,
+) async {
+  final tabFinder = find.text(tabTitle);
+  expect(tabFinder, findsOneWidget);
 
-// TODO 20240902 kev TO MOVE INTO UTILS AS navigateToTab()
-
-Future<void> navigateToExploreTab(WidgetTester tester) async {
-  final exploreIconFinder = find.byIcon(Icons.insights);
-  expect(exploreIconFinder, findsOneWidget);
-
-  await tester.tap(exploreIconFinder);
+  await tester.tap(tabFinder);
   await tester.pumpAndSettle();
 
-  expect(find.byType(ExploreTabs), findsOneWidget);
+  expect(find.byType(panelType), findsOneWidget);
 }

--- a/integration_test/utils/navigate_to_feature.dart
+++ b/integration_test/utils/navigate_to_feature.dart
@@ -1,6 +1,6 @@
 /// Navigate to a feature in the app.
 //
-// Time-stamp: <Tuesday 2024-09-03 09:03:00 +1000 Graham Williams>
+// Time-stamp: <Tuesday 2024-09-10 15:56:42 +1000 Graham Williams>
 //
 /// Copyright (C) 2023-2024, Togaware Pty Ltd
 ///
@@ -27,16 +27,20 @@ library;
 
 import 'package:flutter_test/flutter_test.dart';
 
+import 'delays.dart';
+
 Future<void> navigateToFeature(
   WidgetTester tester,
-  String tabTitle,
+  String feature,
   Type panelType,
 ) async {
-  final tabFinder = find.text(tabTitle);
+  final tabFinder = find.text(feature);
   expect(tabFinder, findsOneWidget);
 
   await tester.tap(tabFinder);
   await tester.pumpAndSettle();
 
   expect(find.byType(panelType), findsOneWidget);
+
+  await tester.pump(pause);
 }

--- a/integration_test/utils/navigate_to_tab.dart
+++ b/integration_test/utils/navigate_to_tab.dart
@@ -25,18 +25,40 @@
 
 library;
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:rattle/tabs/explore.dart';
+import 'package:rattle/tabs/transform.dart';
 
 Future<void> navigateToTab(
   WidgetTester tester,
   String tabTitle,
-  Type panelType,
 ) async {
-  final tabFinder = find.text(tabTitle);
-  expect(tabFinder, findsOneWidget);
+  if (tabTitle == 'Explore') {
+    final exploreIconFinder = find.byIcon(Icons.insights);
+    expect(exploreIconFinder, findsOneWidget);
 
-  await tester.tap(tabFinder);
-  await tester.pumpAndSettle();
+    await tester.tap(exploreIconFinder);
+    await tester.pumpAndSettle();
 
-  expect(find.byType(panelType), findsOneWidget);
+    expect(find.byType(ExploreTabs), findsOneWidget);
+  } else if (tabTitle == 'Transform') {
+    final transformIconFinder = find.byIcon(Icons.transform);
+    expect(transformIconFinder, findsOneWidget);
+
+    await tester.tap(transformIconFinder);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TransformTabs), findsOneWidget);
+  } else if (tabTitle == 'Model') {
+    final modelIconFinder = find.byIcon(Icons.model_training);
+    expect(modelIconFinder, findsOneWidget);
+
+    await tester.tap(modelIconFinder);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TransformTabs), findsOneWidget);
+  } else {
+    throw Exception('Unknown tab title: $tabTitle');
+  }
 }

--- a/integration_test/utils/navigate_to_tab.dart
+++ b/integration_test/utils/navigate_to_tab.dart
@@ -25,40 +25,31 @@
 
 library;
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:rattle/tabs/explore.dart';
-import 'package:rattle/tabs/transform.dart';
+import 'package:rattle/home.dart';
 
 Future<void> navigateToTab(
   WidgetTester tester,
   String tabTitle,
 ) async {
-  if (tabTitle == 'Explore') {
-    final exploreIconFinder = find.byIcon(Icons.insights);
-    expect(exploreIconFinder, findsOneWidget);
+  // Find the tab details from homeTabs list using the tabTitle.
 
-    await tester.tap(exploreIconFinder);
-    await tester.pumpAndSettle();
+  final tab = homeTabs.firstWhere(
+    (element) => element['title'] == tabTitle,
+    orElse: () => throw Exception('Unknown tab title: $tabTitle'),
+  );
 
-    expect(find.byType(ExploreTabs), findsOneWidget);
-  } else if (tabTitle == 'Transform') {
-    final transformIconFinder = find.byIcon(Icons.transform);
-    expect(transformIconFinder, findsOneWidget);
+  // Find the icon associated with the tab.
 
-    await tester.tap(transformIconFinder);
-    await tester.pumpAndSettle();
+  final iconFinder = find.byIcon(tab['icon']);
+  expect(iconFinder, findsOneWidget);
 
-    expect(find.byType(TransformTabs), findsOneWidget);
-  } else if (tabTitle == 'Model') {
-    final modelIconFinder = find.byIcon(Icons.model_training);
-    expect(modelIconFinder, findsOneWidget);
+  // Tap the icon to navigate.
 
-    await tester.tap(modelIconFinder);
-    await tester.pumpAndSettle();
+  await tester.tap(iconFinder);
+  await tester.pumpAndSettle();
 
-    expect(find.byType(TransformTabs), findsOneWidget);
-  } else {
-    throw Exception('Unknown tab title: $tabTitle');
-  }
+  // Check if the widget of the tab is visible.
+
+  expect(find.byType(tab['widget'].runtimeType), findsOneWidget);
 }

--- a/integration_test/utils/navigate_to_tab.dart
+++ b/integration_test/utils/navigate_to_tab.dart
@@ -1,6 +1,6 @@
 /// Navigate to a tab in the app.
 //
-// Time-stamp: <Tuesday 2024-09-03 09:03:00 +1000 Graham Williams>
+// Time-stamp: <Tuesday 2024-09-10 15:56:45 +1000 Graham Williams>
 //
 /// Copyright (C) 2023-2024, Togaware Pty Ltd
 ///
@@ -26,7 +26,10 @@
 library;
 
 import 'package:flutter_test/flutter_test.dart';
+
 import 'package:rattle/home.dart';
+
+import 'delays.dart';
 
 Future<void> navigateToTab(
   WidgetTester tester,
@@ -52,4 +55,6 @@ Future<void> navigateToTab(
   // Check if the widget of the tab is visible.
 
   expect(find.byType(tab['widget'].runtimeType), findsOneWidget);
+
+  await tester.pump(pause);
 }

--- a/integration_test/utils/open_demo_dataset.dart
+++ b/integration_test/utils/open_demo_dataset.dart
@@ -1,6 +1,6 @@
 /// Tester support function to open the DEMO dataset.
 //
-// Time-stamp: <Monday 2024-09-02 18:53:31 +1000 Graham Williams>
+// Time-stamp: <Tuesday 2024-09-10 15:59:58 +1000 Graham Williams>
 //
 /// Copyright (C) 2024, Togaware Pty Ltd
 ///
@@ -35,6 +35,7 @@ import 'delays.dart';
 Future<void> openDemoDataset(WidgetTester tester) async {
   final datasetButtonFinder = find.byType(DatasetButton);
   expect(datasetButtonFinder, findsOneWidget);
+
   await tester.pump(pause);
 
   await tester.tap(datasetButtonFinder);
@@ -43,6 +44,8 @@ Future<void> openDemoDataset(WidgetTester tester) async {
 
   final datasetPopup = find.byType(DatasetPopup);
   expect(datasetPopup, findsOneWidget);
+
+  await tester.pump(pause);
 
   // TODO 20240902 kev DETECT POPUP WARNING AND TAP YES
   //
@@ -61,5 +64,6 @@ Future<void> openDemoDataset(WidgetTester tester) async {
 
   await tester.tap(demoButton);
   await tester.pumpAndSettle();
+
   await tester.pump(pause);
 }


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- delete helper.dart file and rename util functions

- Link to associated issue: #341 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [x] Linux
  - [x] MacOS
  - [ ] Windows
- [ ] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
