### PR TITLE
fix linting error and action warnings

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -186,7 +186,7 @@ jobs:
         with:
           files: build/windows/x64/runner/Release/rattle-${{github.ref_name}}-windows.zip
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rattle-windows-zip
           path: build/windows/x64/runner/Release/rattle-${{github.ref_name}}-windows.zip
@@ -227,7 +227,7 @@ jobs:
         with:
           files: build/macos/Build/Products/Release/rattle-${{github.ref_name}}-macos.zip
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rattle-macos-zip
           path: build/macos/Build/Products/Release/rattle-${{github.ref_name}}-macos.zip

--- a/integration_test/transform_impute_large_test.dart
+++ b/integration_test/transform_impute_large_test.dart
@@ -38,10 +38,6 @@ import 'utils/open_dataset_by_path.dart';
 import 'utils/press_first_button.dart';
 import 'utils/verify_multiple_text.dart';
 import 'utils/verify_next_page.dart';
-import 'utils/check_missing_variable.dart';
-import 'utils/check_variable_not_missing.dart';
-import 'utils/init_app.dart';
-import 'utils/verify_imputed_variable.dart';
 
 void main() {
   // Ensure that the integration test bindings are initialized before running tests.

--- a/integration_test/transform_impute_large_test.dart
+++ b/integration_test/transform_impute_large_test.dart
@@ -38,6 +38,10 @@ import 'utils/open_dataset_by_path.dart';
 import 'utils/press_first_button.dart';
 import 'utils/verify_multiple_text.dart';
 import 'utils/verify_next_page.dart';
+// import 'utils/check_missing_variable.dart';
+// import 'utils/check_variable_not_missing.dart';
+// import 'utils/init_app.dart';
+// import 'utils/verify_imputed_variable.dart';
 
 void main() {
   // Ensure that the integration test bindings are initialized before running tests.


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fix linting error and warning in Github Actions

- Link to associated issue: #

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [ ] Changes adhere to the style and coding guideline
- [ ] No confidential information
- [ ] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [ ] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
