### PR TITLE
Add completer to ensure rStart is passed after pty init

### DIFF
--- a/lib/r/start.dart
+++ b/lib/r/start.dart
@@ -26,6 +26,7 @@
 
 library;
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -99,7 +100,19 @@ void rStart(BuildContext context, WidgetRef ref) async {
   // startup. Seems to have a slight delay on Linux with a all black
   // screen. Let's see what it does on Windows.
 
-  await Future(() {
+  await Future(() async {
+    
+    // Create a Completer to ensure pty is ready before writing to it.
+    Completer<void> ptyReadyCompleter = Completer<void>();
+
+    // Mark the pty as ready after it has been initialized.
+    ref.read(ptyProvider).exitCode.then((_) {
+      ptyReadyCompleter.complete();
+    });
+
+    // extra delay
+    const duration = Duration(seconds: 1);
+    await Future.delayed(duration);
     // Add the code to the script.
 
     updateScript(ref, code);


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- [A one line description of this PR]

- Link to associated issue: #264 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [x] Linux
  - [ ] MacOS
  - [x] Windows
- [x] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
