### PR TITLE
WORDCLOUD IMPROVEMENT: correct order of text cleaning and remove all punctuations

### DIFF
--- a/assets/r/model_build_word_cloud.R
+++ b/assets/r/model_build_word_cloud.R
@@ -37,18 +37,20 @@ text_data <- readLines("FILENAME")
 docs <- Corpus(VectorSource(text_data))
 
 # Preprocessing.
-
-if (STEM) {
-  docs <- tm_map(docs, stemDocument)
-}
+# the order matters!
 
 if (PUNCTUATION) {
-  docs <- tm_map(docs, removePunctuation)
+  docs <- tm_map(docs, removePunctuation, ucp = TRUE)
 }
 
 if (STOPWORD) {
   docs <- tm_map(docs, removeWords, stopwords("LANGUAGE"))
 }
+
+if (STEM) {
+  docs <- tm_map(docs, stemDocument)
+}
+
 
 # Convert text data to a single character string
 #


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- correct order of text cleaning and remove all punctuations

- Link to associated issue: #

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [ ] Changes adhere to the style and coding guideline
- [ ] No confidential information
- [ ] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [ ] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
