### PR TITLE
kev/512_interval

### DIFF
--- a/lib/features/rescale/config.dart
+++ b/lib/features/rescale/config.dart
@@ -102,16 +102,19 @@ class RescaleConfigState extends ConsumerState<RescaleConfig> {
           label: 'Interval',
           tooltip: '''
 
-          When rescaling a numeric variable using an Interval the numeric value
-          here is the maximum value for the resulting interval. A default
-          maximum value of 100 is often used. The minimum value is fixed as 0.
+        When rescaling a numeric variable using an Interval, the numeric value
+        here is the maximum value for the resulting interval. A default
+        maximum value of 100 is often used. The minimum value is fixed as 0.
 
-          ''',
+        ''',
           controller: valCtrl,
           inputFormatter:
               FilteringTextInputFormatter.digitsOnly, // Integers only
           validator: (value) => validateInteger(value, min: 1),
           stateProvider: intervalProvider,
+          // Enable only when "Interval" is selected.
+
+          enabled: selectedTransform == 'Interval',
         ),
       ],
     );

--- a/lib/features/rescale/config.dart
+++ b/lib/features/rescale/config.dart
@@ -5,7 +5,7 @@
 /// License: GNU General Public License, Version 3 (the "License")
 /// https://www.gnu.org/licenses/gpl-3.0.en.html
 //
-// Time-stamp: <Friday 2024-10-11 12:09:30 +1100 Graham Williams>
+// Time-stamp: <Tuesday 2024-10-15 15:23:37 +1100 Graham Williams>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software
@@ -102,16 +102,19 @@ class RescaleConfigState extends ConsumerState<RescaleConfig> {
           label: 'Interval',
           tooltip: '''
 
-        When rescaling a numeric variable using an Interval, the numeric value
-        here is the maximum value for the resulting interval. A default
-        maximum value of 100 is often used. The minimum value is fixed as 0.
+          When rescaling a numeric variable using an Interval, the numeric value
+          here is the maximum value for the resulting interval. A default
+          maximum value of 100 is often used. The minimum value is fixed as 0.
 
-        ''',
+          ''',
           controller: valCtrl,
-          inputFormatter:
-              FilteringTextInputFormatter.digitsOnly, // Integers only
+
+          // Allow integers only.
+
+          inputFormatter: FilteringTextInputFormatter.digitsOnly,
           validator: (value) => validateInteger(value, min: 1),
           stateProvider: intervalProvider,
+
           // Enable only when "Interval" is selected.
 
           enabled: selectedTransform == 'Interval',


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- RESCALE: Interval number field is available only when Interval chip is selected #512

- Link to associated issue: #512 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [x] Linux
  - [x] MacOS
  - [ ] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
