### PR TITLE
Kev/535_table_widget

### DIFF
--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -1,6 +1,6 @@
 /// Dataset display with pages.
 //
-// Time-stamp: <Wednesday 2024-10-23 15:14:37 +1100 Graham Williams>
+// Time-stamp: <Wednesday 2024-10-23 15:17:17 +1100 Graham Williams>
 //
 /// Copyright (C) 2023-2024, Togaware Pty Ltd.
 ///
@@ -230,66 +230,13 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
     }
   }
 
-  // Build headline for the dataset summary.
-
-  Widget _buildHeadline() {
-    return Padding(
-      padding: const EdgeInsets.all(6.0),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const Expanded(
-            child: Text(
-              'Variable',
-              style: TextStyle(fontWeight: FontWeight.bold),
-              textAlign: TextAlign.left,
-            ),
-          ),
-          Expanded(
-            flex: typeFlex,
-            child: const Text(
-              '      Role',
-              style: TextStyle(fontWeight: FontWeight.bold),
-              textAlign: TextAlign.left,
-            ),
-          ),
-          const Expanded(
-            child: Text(
-              'Type',
-              style: TextStyle(fontWeight: FontWeight.bold),
-              textAlign: TextAlign.left,
-            ),
-          ),
-          const Expanded(
-            child: Text(
-              'Unique',
-              style: TextStyle(fontWeight: FontWeight.bold),
-              textAlign: TextAlign.right,
-            ),
-          ),
-          const Expanded(
-            child: Text(
-              'Missing',
-              style: TextStyle(fontWeight: FontWeight.bold),
-              textAlign: TextAlign.right,
-            ),
-          ),
-          Expanded(
-            flex: contentFlex,
-            child: const Text(
-              '      Sample',
-              style: TextStyle(fontWeight: FontWeight.bold),
-              textAlign: TextAlign.left,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
   // Build data line for each variable, including the table header if specified.
 
-  Widget _buildDataTable(VariableInfo variable, Map<String, Role> currentRoles,
-      {bool showHeader = false}) {
+  Widget _buildDataTable(
+    VariableInfo variable,
+    Map<String, Role> currentRoles, {
+    bool showHeader = false,
+  }) {
     // Truncate the content to fit one line. The text could wrap over two
     // lines and so show more of the data, but our point here is more to
     // have a reminder of the data to assist in deciding on the ROLE of each
@@ -482,7 +429,11 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
             elevation: 2.0,
             selected: remap(currentRoles[columnName]!, choice),
             onSelected: (bool selected) => _handleRoleSelection(
-                selected, choice, columnName, currentRoles),
+              selected,
+              choice,
+              columnName,
+              currentRoles,
+            ),
           );
         }).toList(),
       ),

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -372,7 +372,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                 Text(
                   'Missing',
                   style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.center,
+                  textAlign: TextAlign.right,
                 ),
 
                 // Header for content.
@@ -428,7 +428,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
 
               Text(
                 formatter.format(missingCount),
-                textAlign: TextAlign.center,
+                textAlign: TextAlign.right,
               ),
 
               // Content column.

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -148,7 +148,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
         itemBuilder: (context, index) {
           // Show header only for the first row.
 
-          return _buildDataLine(
+          return _buildDataTable(
             vars[index],
             currentRoles,
             showHeader: index == 0,
@@ -286,7 +286,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
   }
 // Build data line for each variable, including the table header if specified.
 
-  Widget _buildDataLine(VariableInfo variable, Map<String, Role> currentRoles,
+  Widget _buildDataTable(VariableInfo variable, Map<String, Role> currentRoles,
       {bool showHeader = false}) {
     // Truncate the content to fit one line. The text could wrap over two
     // lines and so show more of the data, but our point here is more to
@@ -361,7 +361,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                   child: Text(
                     'Unique',
                     style: TextStyle(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.right,
+                    textAlign: TextAlign.center,
                   ),
                 ),
 
@@ -372,7 +372,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                   child: Text(
                     'Missing',
                     style: TextStyle(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.right,
+                    textAlign: TextAlign.center,
                   ),
                 ),
 
@@ -412,14 +412,14 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
 
               Text(
                 formatter.format(uniqueCount),
-                textAlign: TextAlign.right,
+                textAlign: TextAlign.center,
               ),
 
               // Missing count column.
 
               Text(
                 formatter.format(missingCount),
-                textAlign: TextAlign.right,
+                textAlign: TextAlign.center,
               ),
 
               // Content column.

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -284,7 +284,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
       ),
     );
   }
-// Build data line for each variable, including the table header if specified.
+  // Build data line for each variable, including the table header if specified.
 
   Widget _buildDataTable(VariableInfo variable, Map<String, Role> currentRoles,
       {bool showHeader = false}) {
@@ -308,12 +308,14 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
       padding: const EdgeInsets.all(6.0),
       child: Table(
         columnWidths: const {
-          0: FlexColumnWidth(),
-          1: FlexColumnWidth(4),
-          2: FlexColumnWidth(),
-          3: FlexColumnWidth(),
-          4: FlexColumnWidth(),
-          5: FlexColumnWidth(3),
+          0: FlexColumnWidth(), // Variable name column.
+          // 1: FlexColumnWidth(4), // Role column.
+          1: FixedColumnWidth(500.0), // Type column.
+
+          2: FixedColumnWidth(60.0), // Type column.
+          3: FixedColumnWidth(60.0), // Unique column.
+          4: FixedColumnWidth(70.0), // Missing column.
+          5: FlexColumnWidth(3), // Content column.
         },
         children: [
           if (showHeader)
@@ -334,7 +336,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                 Text(
                   'Role',
                   style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.left,
+                  textAlign: TextAlign.center,
                 ),
 
                 // Header for type.
@@ -342,10 +344,11 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                 Text(
                   'Type',
                   style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.left,
+                  textAlign: TextAlign.center,
                 ),
 
                 // Header for unique count.
+
                 Text(
                   'Unique',
                   style: TextStyle(fontWeight: FontWeight.bold),
@@ -353,6 +356,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                 ),
 
                 // Header for missing count.
+
                 Text(
                   'Missing',
                   style: TextStyle(fontWeight: FontWeight.bold),
@@ -360,10 +364,11 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                 ),
 
                 // Header for content.
+
                 Text(
                   'Sample',
                   style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.left,
+                  textAlign: TextAlign.center,
                 ),
               ],
             ),
@@ -384,7 +389,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
 
               Text(
                 variable.type,
-                textAlign: TextAlign.left,
+                textAlign: TextAlign.center,
               ),
 
               // Unique count column.
@@ -405,7 +410,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
 
               SelectableText(
                 content,
-                textAlign: TextAlign.left,
+                textAlign: TextAlign.center,
               ),
             ],
           ),
@@ -432,24 +437,26 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
   // Build role choice chips.
 
   Widget _buildRoleChips(String columnName, Map<String, Role> currentRoles) {
-    return Wrap(
-      spacing: 5.0,
-      runSpacing: choiceChipRowSpace,
-      children: choices.map((choice) {
-        return ChoiceChip(
-          label: Text(choice.displayString),
-          disabledColor: Colors.grey,
-          selectedColor: Colors.lightBlue[200],
-          backgroundColor: Colors.lightBlue[50],
-          showCheckmark: false,
-          shadowColor: Colors.grey,
-          pressElevation: 8.0,
-          elevation: 2.0,
-          selected: remap(currentRoles[columnName]!, choice),
-          onSelected: (bool selected) =>
-              _handleRoleSelection(selected, choice, columnName, currentRoles),
-        );
-      }).toList(),
+    return Center(
+      child: Wrap(
+        spacing: 5.0,
+        runSpacing: choiceChipRowSpace,
+        children: choices.map((choice) {
+          return ChoiceChip(
+            label: Text(choice.displayString),
+            disabledColor: Colors.grey,
+            selectedColor: Colors.lightBlue[200],
+            backgroundColor: Colors.lightBlue[50],
+            showCheckmark: false,
+            shadowColor: Colors.grey,
+            pressElevation: 8.0,
+            elevation: 2.0,
+            selected: remap(currentRoles[columnName]!, choice),
+            onSelected: (bool selected) => _handleRoleSelection(
+                selected, choice, columnName, currentRoles),
+          );
+        }).toList(),
+      ),
     );
   }
 

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -53,6 +53,8 @@ import 'package:rattle/widgets/page_viewer.dart';
 import 'package:rattle/utils/show_markdown_file_2.dart';
 import 'package:rattle/widgets/text_page.dart';
 
+const smallSpace = SizedBox(height: 10);
+
 /// The dataset panel displays the RattleNG welcome on the first page and the
 /// ROLES as the second page.
 
@@ -387,12 +389,12 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
 
           TableRow(
             children: [
-              SizedBox(height: 10),
-              SizedBox(height: 10),
-              SizedBox(height: 10),
-              SizedBox(height: 10),
-              SizedBox(height: 10),
-              SizedBox(height: 10),
+              smallSpace,
+              smallSpace,
+              smallSpace,
+              smallSpace,
+              smallSpace,
+              smallSpace,
             ],
           ),
 

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -308,14 +308,24 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
       padding: const EdgeInsets.all(6.0),
       child: Table(
         columnWidths: const {
-          0: FlexColumnWidth(), // Variable name column.
-          // 1: FlexColumnWidth(4), // Role column.
-          1: FixedColumnWidth(500.0), // Type column.
+          // Variable name column.
 
-          2: FixedColumnWidth(60.0), // Type column.
-          3: FixedColumnWidth(60.0), // Unique column.
-          4: FixedColumnWidth(70.0), // Missing column.
-          5: FlexColumnWidth(3), // Content column.
+          0: FlexColumnWidth(),
+          // Role column.
+
+          1: FixedColumnWidth(500.0),
+          // Type column.
+
+          2: FixedColumnWidth(80.0),
+          // Unique column.
+
+          3: FixedColumnWidth(80.0),
+          // Missing column.
+
+          4: FixedColumnWidth(80.0),
+          // Content column.
+
+          5: FlexColumnWidth(3),
         },
         children: [
           if (showHeader)
@@ -372,6 +382,19 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                 ),
               ],
             ),
+
+          // Extra space after header row.
+
+          TableRow(
+            children: [
+              SizedBox(height: 10),
+              SizedBox(height: 10),
+              SizedBox(height: 10),
+              SizedBox(height: 10),
+              SizedBox(height: 10),
+              SizedBox(height: 10),
+            ],
+          ),
 
           // Table data row for variable.
 

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -141,23 +141,17 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
       ListView.builder(
         key: const Key('roles_list_view'),
 
-        // Add 1 for the extra header row.
+        // Item count is the same as the number of variables.
 
-        itemCount: vars.length + 1,
+        itemCount: vars.length,
 
         itemBuilder: (context, index) {
-          // Both the header row and the regular row shares the same flex
-          // index.
+          // Each row represents a data line for a variable.
 
-          return index == 0
-              ? _buildHeadline()
-              :
-              // Regular data rows. We subtract 1 from the index to get the
-              // correct variable since the first row is the header row.
-              _buildDataLine(
-                  vars[index - 1],
-                  currentRoles,
-                );
+          return _buildDataLine(
+            vars[index],
+            currentRoles,
+          );
         },
       ),
     );
@@ -289,8 +283,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
       ),
     );
   }
-
-  // Build data line for each variable.
+// Build data line for each variable, including the table header.
 
   Widget _buildDataLine(VariableInfo variable, Map<String, Role> currentRoles) {
     // Truncate the content to fit one line. The text could wrap over two
@@ -307,87 +300,134 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
     int uniqueCount = metaData[variable.name]?['unique']?[0] ?? 0;
     int missingCount = metaData[variable.name]?['missing']?[0] ?? 0;
 
+    var formatter = NumberFormat('#,###');
+
     return Padding(
       padding: const EdgeInsets.all(6.0),
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          // Define a dynamic space based on the available width.
-          // 2% of available width.
+      child: Table(
+        columnWidths: const {
+          0: FlexColumnWidth(),
+          1: FlexColumnWidth(4),
+          2: FlexColumnWidth(),
+          3: FlexColumnWidth(),
+          4: FlexColumnWidth(),
+          5: FlexColumnWidth(3),
+        },
+        children: [
+          // Table header row.
 
-          double dynamicSpace = constraints.maxWidth * 0.02;
-
-          var formatter = NumberFormat('#,###');
-
-          return Row(
-            // Same alignment.
-
-            crossAxisAlignment: CrossAxisAlignment.start,
+          const TableRow(
             children: [
-              Expanded(child: _buildFittedText(variable.name)),
+              // Header for variable name.
 
-              // Three dynamic spaces to make the visual space between the
-              // columns consistent.
-
-              SizedBox(width: dynamicSpace),
-
-              Expanded(
-                // Matching flex value for alignment.
-
-                flex: typeFlex,
-                child: _buildRoleChips(variable.name, currentRoles),
-              ),
-
-              Expanded(
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: 4.0),
                 child: Text(
-                  variable.type,
-                  // Match header alignment.
-
+                  'Variable',
+                  style: TextStyle(fontWeight: FontWeight.bold),
                   textAlign: TextAlign.left,
                 ),
               ),
 
-              SizedBox(width: dynamicSpace),
+              // Header for role.
 
-              Expanded(
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: 4.0),
                 child: Text(
-                  // Unique count.
+                  'Role',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.left,
+                ),
+              ),
 
-                  formatter.format(uniqueCount),
+              // Header for type.
 
-                  // Match header alignment.
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: 4.0),
+                child: Text(
+                  'Type',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.left,
+                ),
+              ),
 
+              // Header for unique count.
+
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: 4.0),
+                child: Text(
+                  'Unique',
+                  style: TextStyle(fontWeight: FontWeight.bold),
                   textAlign: TextAlign.right,
                 ),
               ),
 
-              SizedBox(width: dynamicSpace),
+              // Header for missing count.
 
-              Expanded(
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: 4.0),
                 child: Text(
-                  // Missing count.
-
-                  formatter.format(missingCount),
-
-                  // Match header alignment.
-
+                  'Missing',
+                  style: TextStyle(fontWeight: FontWeight.bold),
                   textAlign: TextAlign.right,
                 ),
               ),
 
-              SizedBox(width: dynamicSpace),
+              // Header for content.
 
-              Expanded(
-                // Matching flex value for alignment.
-
-                flex: contentFlex,
-                child: SelectableText(
-                  content,
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: 4.0),
+                child: Text(
+                  'Sample',
+                  style: TextStyle(fontWeight: FontWeight.bold),
                   textAlign: TextAlign.left,
                 ),
               ),
             ],
-          );
-        },
+          ),
+
+          // Table data row for variable.
+
+          TableRow(
+            children: [
+              // Variable name column.
+
+              _buildFittedText(variable.name),
+
+              // Role choice chips column.
+
+              _buildRoleChips(variable.name, currentRoles),
+
+              // Variable type column.
+
+              Text(
+                variable.type,
+                textAlign: TextAlign.left,
+              ),
+
+              // Unique count column.
+
+              Text(
+                formatter.format(uniqueCount),
+                textAlign: TextAlign.right,
+              ),
+
+              // Missing count column.
+
+              Text(
+                formatter.format(missingCount),
+                textAlign: TextAlign.right,
+              ),
+
+              // Content column.
+
+              SelectableText(
+                content,
+                textAlign: TextAlign.left,
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }
@@ -397,7 +437,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
   Widget _buildFittedText(String text) {
     return FittedBox(
       fit: BoxFit.scaleDown,
-      alignment: Alignment.center,
+      alignment: Alignment.topLeft,
       child: Text(
         text,
         maxLines: 1,

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -146,11 +146,12 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
         itemCount: vars.length,
 
         itemBuilder: (context, index) {
-          // Each row represents a data line for a variable.
+          // Show header only for the first row.
 
           return _buildDataLine(
             vars[index],
             currentRoles,
+            showHeader: index == 0,
           );
         },
       ),
@@ -283,9 +284,10 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
       ),
     );
   }
-// Build data line for each variable, including the table header.
+// Build data line for each variable, including the table header if specified.
 
-  Widget _buildDataLine(VariableInfo variable, Map<String, Role> currentRoles) {
+  Widget _buildDataLine(VariableInfo variable, Map<String, Role> currentRoles,
+      {bool showHeader = false}) {
     // Truncate the content to fit one line. The text could wrap over two
     // lines and so show more of the data, but our point here is more to
     // have a reminder of the data to assist in deciding on the ROLE of each
@@ -314,77 +316,78 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
           5: FlexColumnWidth(3),
         },
         children: [
-          // Table header row.
+          if (showHeader)
+            // Table header row.
 
-          const TableRow(
-            children: [
-              // Header for variable name.
+            const TableRow(
+              children: [
+                // Header for variable name.
 
-              Padding(
-                padding: EdgeInsets.symmetric(vertical: 4.0),
-                child: Text(
-                  'Variable',
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.left,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 4.0),
+                  child: Text(
+                    'Variable',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.left,
+                  ),
                 ),
-              ),
 
-              // Header for role.
+                // Header for role.
 
-              Padding(
-                padding: EdgeInsets.symmetric(vertical: 4.0),
-                child: Text(
-                  'Role',
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.left,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 4.0),
+                  child: Text(
+                    'Role',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.left,
+                  ),
                 ),
-              ),
 
-              // Header for type.
+                // Header for type.
 
-              Padding(
-                padding: EdgeInsets.symmetric(vertical: 4.0),
-                child: Text(
-                  'Type',
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.left,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 4.0),
+                  child: Text(
+                    'Type',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.left,
+                  ),
                 ),
-              ),
 
-              // Header for unique count.
+                // Header for unique count.
 
-              Padding(
-                padding: EdgeInsets.symmetric(vertical: 4.0),
-                child: Text(
-                  'Unique',
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.right,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 4.0),
+                  child: Text(
+                    'Unique',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.right,
+                  ),
                 ),
-              ),
 
-              // Header for missing count.
+                // Header for missing count.
 
-              Padding(
-                padding: EdgeInsets.symmetric(vertical: 4.0),
-                child: Text(
-                  'Missing',
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.right,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 4.0),
+                  child: Text(
+                    'Missing',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.right,
+                  ),
                 ),
-              ),
 
-              // Header for content.
+                // Header for content.
 
-              Padding(
-                padding: EdgeInsets.symmetric(vertical: 4.0),
-                child: Text(
-                  'Sample',
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.left,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 4.0),
+                  child: Text(
+                    'Sample',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.left,
+                  ),
                 ),
-              ),
-            ],
-          ),
+              ],
+            ),
 
           // Table data row for variable.
 

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -323,68 +323,47 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
               children: [
                 // Header for variable name.
 
-                Padding(
-                  padding: EdgeInsets.symmetric(vertical: 4.0),
-                  child: Text(
-                    'Variable',
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.left,
-                  ),
+                Text(
+                  'Variable',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.left,
                 ),
 
                 // Header for role.
 
-                Padding(
-                  padding: EdgeInsets.symmetric(vertical: 4.0),
-                  child: Text(
-                    'Role',
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.left,
-                  ),
+                Text(
+                  'Role',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.left,
                 ),
 
                 // Header for type.
 
-                Padding(
-                  padding: EdgeInsets.symmetric(vertical: 4.0),
-                  child: Text(
-                    'Type',
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.left,
-                  ),
+                Text(
+                  'Type',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.left,
                 ),
 
                 // Header for unique count.
-
-                Padding(
-                  padding: EdgeInsets.symmetric(vertical: 4.0),
-                  child: Text(
-                    'Unique',
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.center,
-                  ),
+                Text(
+                  'Unique',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.center,
                 ),
 
                 // Header for missing count.
-
-                Padding(
-                  padding: EdgeInsets.symmetric(vertical: 4.0),
-                  child: Text(
-                    'Missing',
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.center,
-                  ),
+                Text(
+                  'Missing',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.center,
                 ),
 
                 // Header for content.
-
-                Padding(
-                  padding: EdgeInsets.symmetric(vertical: 4.0),
-                  child: Text(
-                    'Sample',
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.left,
-                  ),
+                Text(
+                  'Sample',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.left,
                 ),
               ],
             ),

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -1,6 +1,6 @@
 /// Dataset display with pages.
 //
-// Time-stamp: <Friday 2024-10-18 05:45:40 +1100 Graham Williams>
+// Time-stamp: <Wednesday 2024-10-23 15:14:37 +1100 Graham Williams>
 //
 /// Copyright (C) 2023-2024, Togaware Pty Ltd.
 ///
@@ -311,23 +311,19 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
       child: Table(
         columnWidths: const {
           // Variable name column.
-
-          0: FlexColumnWidth(),
+          0: FixedColumnWidth(150.0),
           // Role column.
-
-          1: FixedColumnWidth(500.0),
+          1: FixedColumnWidth(400.0),
           // Type column.
-
-          2: FixedColumnWidth(80.0),
+          2: FixedColumnWidth(40.0),
           // Unique column.
-
           3: FixedColumnWidth(80.0),
           // Missing column.
-
           4: FixedColumnWidth(80.0),
+          // Gap of 20px between the columns
+          5: FixedColumnWidth(20.0),
           // Content column.
-
-          5: FlexColumnWidth(3),
+          6: FlexColumnWidth(),
         },
         children: [
           if (showHeader)
@@ -364,7 +360,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                 Text(
                   'Unique',
                   style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.center,
+                  textAlign: TextAlign.right,
                 ),
 
                 // Header for missing count.
@@ -375,12 +371,16 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                   textAlign: TextAlign.right,
                 ),
 
+                // Empty cell acting as a gap
+
+                SizedBox.shrink(),
+
                 // Header for content.
 
                 Text(
                   'Sample',
                   style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.center,
+                  textAlign: TextAlign.left,
                 ),
               ],
             ),
@@ -389,6 +389,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
 
           TableRow(
             children: [
+              smallSpace,
               smallSpace,
               smallSpace,
               smallSpace,
@@ -421,7 +422,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
 
               Text(
                 formatter.format(uniqueCount),
-                textAlign: TextAlign.center,
+                textAlign: TextAlign.right,
               ),
 
               // Missing count column.
@@ -431,11 +432,14 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
                 textAlign: TextAlign.right,
               ),
 
+              // Empty cell acting as a gap
+
+              SizedBox.shrink(),
               // Content column.
 
               SelectableText(
                 content,
-                textAlign: TextAlign.center,
+                textAlign: TextAlign.left,
               ),
             ],
           ),
@@ -522,7 +526,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
   // Truncate content for display.
 
   String _truncateContent(String content) {
-    int maxLength = 30;
+    int maxLength = 50;
     String subStr =
         content.length > maxLength ? content.substring(0, maxLength) : content;
     int lastCommaIndex = subStr.lastIndexOf(',') + 1;


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- DATASET: Align Variables to the Left and Convert ROLES Page Data into a Flutter Table Widget


- Link to associated issue: #535 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
