### PR TITLE
zy/385 make default image smaller

### DIFF
--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -224,29 +224,24 @@ class ImagePage extends StatelessWidget {
                   LayoutBuilder(
                     builder: (context, constraints) {
                       // The max available width from LayoutBuilder.
+
                       final maxWidth = constraints.maxWidth;
 
                       // Apply a bounded height to avoid infinite height error.
+                      
                       final double maxHeight =
-                          MediaQuery.of(context).size.height * 0.8;
+                          MediaQuery.of(context).size.height * 0.6;
 
                       return SizedBox(
                         height: maxHeight,
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          mainAxisSize: MainAxisSize.max,
-                          children: [
-                            Expanded(
-                              child: InteractiveViewer(
-                                maxScale: 5,
-                                child: SvgPicture.memory(
-                                  bytes,
-                                  width: maxWidth,
-                                  fit: BoxFit.contain,
-                                ),
-                              ),
-                            ),
-                          ],
+                        width: maxWidth,
+                        child: InteractiveViewer(
+                          maxScale: 5,
+                          alignment: Alignment.topCenter,
+                          child: SvgPicture.memory(
+                            bytes,
+                            fit: BoxFit.scaleDown,
+                          ),
                         ),
                       );
                     },


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- IMAGE: Images are too large by default.

- Link to associated issue: #385 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
