### PR TITLE
Supports selecting file extensions, and adds export to PDF and PNG

### DIFF
--- a/lib/utils/select_file.dart
+++ b/lib/utils/select_file.dart
@@ -29,13 +29,17 @@ library;
 
 import 'package:file_picker/file_picker.dart';
 
-Future<String?> selectFile({String defaultFileName = 'image.svg'}) async {
+Future<String?> selectFile({
+  String defaultFileName = 'image.svg',
+  List<String> allowedExtensions = const ['svg'],
+}) async {
   // Use the [FilePicker] to select a file asynchronously so as not to block the
   // main UI thread.
 
   String? result = await FilePicker.platform.saveFile(
-    dialogTitle: 'Provide a .svg filename to save SVG image to',
-    // TODO 20240604 gjw DEFAULT FILE NAME, TILE, ETC DOES NOT APPEAR IN DIALOG.
+    dialogTitle: 'Provide a filename to save the file to',
+
+    // NOTE 20240604 gjw DEFAULT FILE NAME, TILE, ETC DOES NOT APPEAR IN DIALOG.
     //
     // Seems to be a Linux or even Ubuntu/Gnome issue. However it works okay for
     // saving in the SCRIPT tab? Works for Lutra-Fs on Windows and Linux
@@ -43,7 +47,7 @@ Future<String?> selectFile({String defaultFileName = 'image.svg'}) async {
 
     fileName: defaultFileName,
     type: FileType.custom,
-    allowedExtensions: ['svg'],
+    allowedExtensions: allowedExtensions,
   );
 
   return result;

--- a/lib/utils/select_file.dart
+++ b/lib/utils/select_file.dart
@@ -1,6 +1,6 @@
-/// Promote the user to pick a location to save the file
+/// Promt the user to select a name and location to save a file.
 //
-// Time-stamp: <Sunday 2024-09-08 13:47:39 +1000 Graham Williams>
+// Time-stamp: <Friday 2024-11-01 09:51:36 +1100 Graham Williams>
 //
 /// Copyright (C) 2024, Togaware Pty Ltd
 ///
@@ -21,11 +21,9 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Yixiang Yin, Graham Williams
+/// Authors: Yixiang Yin, Graham Williams, Lutra
 
 library;
-
-// Group imports by dart, flutter, packages, local. Then alphabetically.
 
 import 'package:file_picker/file_picker.dart';
 
@@ -33,18 +31,11 @@ Future<String?> selectFile({
   String defaultFileName = 'image.svg',
   List<String> allowedExtensions = const ['svg'],
 }) async {
-  // Use the [FilePicker] to select a file asynchronously so as not to block the
-  // main UI thread.
+  // Use a [FilePicker] to select a file. This is performed asynchronously so as
+  // not to block the main UI thread.
 
   String? result = await FilePicker.platform.saveFile(
     dialogTitle: 'Provide a filename to save the file to',
-
-    // NOTE 20240604 gjw DEFAULT FILE NAME, TILE, ETC DOES NOT APPEAR IN DIALOG.
-    //
-    // Seems to be a Linux or even Ubuntu/Gnome issue. However it works okay for
-    // saving in the SCRIPT tab? Works for Lutra-Fs on Windows and Linux
-    // (zenity). 20240908 gjw
-
     fileName: defaultFileName,
     type: FileType.custom,
     allowedExtensions: allowedExtensions,

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -116,6 +116,7 @@ class ImagePage extends StatelessWidget {
     if (byteData == null) {
       throw Exception('Failed to convert SVG to image bytes');
     }
+    
     return byteData;
   }
 
@@ -312,7 +313,8 @@ class ImagePage extends StatelessWidget {
                                   builder: (context) => AlertDialog(
                                     title: const Text('Error'),
                                     content: const Text(
-                                        'Unsupported file extension, please select a file with .svg, .pdf, or .png extension.',),
+                                      'Unsupported file extension, please select a file with .svg, .pdf, or .png extension.',
+                                    ),
                                     actions: [
                                       TextButton(
                                         onPressed: () => Navigator.pop(context),

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -261,7 +261,7 @@ class ImagePage extends StatelessWidget {
                           ),
 
                           // do not hide the message from DelayedTooltip
-                          
+
                           tooltip: '',
                           onSelected: (String result) async {
                             String fileName = path.split('/').last;

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -291,9 +291,9 @@ class ImagePage extends StatelessWidget {
                             color: Colors.blue,
                           ),
                           onPressed: () async {
-                            String defaultFileName = 'image.svg';
+                            String fileName = path.split('/').last;
                             String? pathToSave = await selectFile(
-                              defaultFileName: defaultFileName,
+                              defaultFileName: fileName,
                               allowedExtensions: ['svg', 'pdf', 'png'],
                             );
                             if (pathToSave != null) {


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Add native functionality to convert SVG to PDF and PNG in app.

- Link to associated issue: #198

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [x] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
