### PR TITLE
kev/616_vertical_scrollbar_on_right_side

### DIFF
--- a/lib/widgets/text_page.dart
+++ b/lib/widgets/text_page.dart
@@ -133,15 +133,28 @@ class TextPage extends StatelessWidget {
 
           Expanded(
             child: Scrollbar(
-              controller: horizontalScrollController,
               thumbVisibility: true,
+              // Attach the horizontal controller.
+
+              controller: horizontalScrollController,
               child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                controller: horizontalScrollController,
-                child: SelectableText(
-                  content,
-                  style: monoTextStyle,
-                  textAlign: TextAlign.left,
+                // Attach a vertical controller for independent scrolling.
+
+                controller: ScrollController(),
+                scrollDirection: Axis.vertical,
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  controller: horizontalScrollController,
+                  child: Container(
+                    // Ensure width matches the full container.
+
+                    width: MediaQuery.of(context).size.width,
+                    child: SelectableText(
+                      content,
+                      style: monoTextStyle,
+                      textAlign: TextAlign.left,
+                    ),
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- TEXT PAGE: Ensure the vertical scroll bar is always on the far right #616


- Link to associated issue: #616 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
