### PR TITLE
kev/627_add_tooltips

### DIFF
--- a/lib/utils/show_settings_dialog.dart
+++ b/lib/utils/show_settings_dialog.dart
@@ -495,10 +495,14 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                               },
                               '''
 
-                              **Cleanse Toggle:** \n
-                              Cleansing prepares the dataset by: \n
-                              - Removing columns with a single constant value.\n
-                              - Converting character columns with limited unique values to categoric factors. \n
+                              **Cleanse Toggle:** 
+
+                              Cleansing prepares the dataset by: 
+
+                              - Removing columns with a single constant value.
+
+                              - Converting character columns with limited unique values to categoric factors. 
+
                               Enable for automated cleansing, or disable if not required.
 
                               ''',
@@ -515,10 +519,14 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                               },
                               '''
 
-                              **Unify Toggle:** \n
-                              Unifies dataset column names by:\n
-                              - Converting names to lowercase.\n
-                              - Replacing spaces with underscores. \n
+                              **Unify Toggle:** 
+
+                              Unifies dataset column names by:
+
+                              - Converting names to lowercase.
+
+                              - Replacing spaces with underscores. 
+
                               Enable for consistent formatting, or disable if original names are preferred.
 
                               ''',
@@ -535,11 +543,16 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                               },
                               '''
 
-                              **Partition Toggle:** \n
-                              Splits the dataset into subsets for predictive modeling:\n
-                              - **Training:** Builds the model.\n
-                              - **Validation:** Tunes the model.\n
-                              - **Testing:** Evaluates model performance. \n
+                              **Partition Toggle:** 
+
+                              Splits the dataset into subsets for predictive modeling:
+
+                              - **Training:** Builds the model.
+
+                              - **Validation:** Tunes the model.
+
+                              - **Testing:** Evaluates model performance. 
+
                               Enable for larger datasets, or disable for exploratory analysis.
 
                               ''',
@@ -548,8 +561,10 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                           MarkdownTooltip(
                             message: '''
 
-                            **Keep in Sync Toggle:** \n
-                            - **On:** Saves toggle changes for current sessions. \n
+                            **Keep in Sync Toggle:** 
+
+                            - **On:** Saves toggle changes for current sessions. 
+
                             - **Off:** Changes are only recovered on restart.
 
                             ''',
@@ -561,8 +576,10 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                           MarkdownTooltip(
                             message: '''
 
-                            **Keep in Sync Toggle:** \n
-                            - **On:** Saves toggle changes for current sessions. \n
+                            **Keep in Sync Toggle:** 
+
+                            - **On:** Saves toggle changes for current sessions. 
+
                             - **Off:** Changes are only recovered on restart.
 
                             ''',
@@ -799,7 +816,7 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                             **Session Control:** This setting determines whether a confirmation popup 
                             appears when the user tries to quit the application. 
                   
-                            - **ON**: A popup will appear asking the user to confirm quitting.\n
+                            - **ON**: A popup will appear asking the user to confirm quitting.
                   
                             - **OFF**: The application will exit immediately without a confirmation popup.
                   
@@ -855,7 +872,7 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                   
                             **Toggle Session Control:**
                   
-                            - Slide to **ON** to enable a confirmation popup when exiting the application.\n
+                            - Slide to **ON** to enable a confirmation popup when exiting the application.
                   
                             - Slide to **OFF** to disable the popup, allowing the app to exit directly.
                   

--- a/lib/utils/show_settings_dialog.dart
+++ b/lib/utils/show_settings_dialog.dart
@@ -500,7 +500,7 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                               - Removing columns with a single constant value.\n
                               - Converting character columns with limited unique values to categoric factors. \n
                               Enable for automated cleansing, or disable if not required.
-                              
+
                               ''',
                             ),
                           ),
@@ -608,10 +608,10 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                           MarkdownTooltip(
                             message: '''
 
-                           **Reset Theme:** Tap here to reset the Graphic Theme
-                            setting to the default theme for Rattle.
-                          
-                          ''',
+                            **Reset Theme:** Tap here to reset the Graphic Theme
+                              setting to the default theme for Rattle.
+                            
+                            ''',
                             child: ElevatedButton(
                               onPressed: () {
                                 setState(() {

--- a/lib/utils/show_settings_dialog.dart
+++ b/lib/utils/show_settings_dialog.dart
@@ -491,9 +491,15 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                               (value) {
                                 ref.read(cleanseProvider.notifier).state =
                                     value;
-
                                 _saveToggleStates();
                               },
+                              '''
+                              **Cleanse Toggle:** \n
+                              Cleansing prepares the dataset by: \n
+                              - Removing columns with a single constant value.\n
+                              - Converting character columns with limited unique values to categoric factors. \n
+                              Enable for automated cleansing, or disable if not required.
+                              ''',
                             ),
                           ),
                           Expanded(
@@ -503,9 +509,15 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                               (value) {
                                 ref.read(normaliseProvider.notifier).state =
                                     value;
-
                                 _saveToggleStates();
                               },
+                              '''
+                              **Unify Toggle:** \n
+                              Unifies dataset column names by:\n
+                              - Converting names to lowercase.\n
+                              - Replacing spaces with underscores. \n
+                              Enable for consistent formatting, or disable if original names are preferred.
+                              ''',
                             ),
                           ),
                           Expanded(
@@ -515,29 +527,46 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                               (value) {
                                 ref.read(partitionProvider.notifier).state =
                                     value;
-
                                 _saveToggleStates();
+                              },
+                              '''
+                              **Partition Toggle:** \n
+                              Splits the dataset into subsets for predictive modeling:\n
+                              - **Training:** Builds the model.\n
+                              - **Validation:** Tunes the model.\n
+                              - **Testing:** Evaluates model performance. \n
+                              Enable for larger datasets, or disable for exploratory analysis.
+                              ''',
+                            ),
+                          ),
+                          MarkdownTooltip(
+                            message: '''
+                            **Keep in Sync Toggle:** \n
+                            - **On:** Saves toggle changes for current sessions. \n
+                            - **Off:** Changes are only recovered on restart.
+                            ''',
+                            child: const Text(
+                              'Keep in Sync',
+                              style: TextStyle(fontSize: 16),
+                            ),
+                          ),
+                          MarkdownTooltip(
+                            message: '''
+                            **Keep in Sync Toggle:** \n
+                            - **On:** Saves toggle changes for current sessions. \n
+                            - **Off:** Changes are only recovered on restart.
+                            ''',
+                            child: Switch(
+                              value: keepInSync,
+                              onChanged: (value) {
+                                ref.read(keepInSyncProvider.notifier).state =
+                                    value;
+                                _saveKeepInSync(value);
                               },
                             ),
                           ),
-                          const Text(
-                            'Keep in Sync',
-                            style: TextStyle(
-                              fontSize: 16,
-                            ),
-                          ),
-                          Switch(
-                            value: keepInSync,
-                            onChanged: (value) {
-                              ref.read(keepInSyncProvider.notifier).state =
-                                  value;
-
-                              _saveKeepInSync(value);
-                            },
-                          ),
                         ],
                       ),
-
                       settingsGroupGap,
                       Divider(),
 
@@ -568,11 +597,11 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
 
                           MarkdownTooltip(
                             message: '''
-                  
-                            **Reset Theme:** Tap here to reset the Graphic Theme
-                              setting to the default theme for Rattle.
-                            
-                            ''',
+
+                           **Reset Theme:** Tap here to reset the Graphic Theme
+                            setting to the default theme for Rattle.
+                          
+                          ''',
                             child: ElevatedButton(
                               onPressed: () {
                                 setState(() {
@@ -862,21 +891,23 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
     String label,
     bool value,
     ValueChanged<bool> onChanged,
+    String tooltipMessage, // Tooltip message for the entire row
   ) {
-    return Row(
-      // Align items to the start.
-
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: [
-        Text(
-          label,
-          style: const TextStyle(fontSize: 16),
-        ),
-        Switch(
-          value: value,
-          onChanged: onChanged,
-        ),
-      ],
+    return MarkdownTooltip(
+      message: tooltipMessage,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(fontSize: 16),
+          ),
+          Switch(
+            value: value,
+            onChanged: onChanged,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/utils/show_settings_dialog.dart
+++ b/lib/utils/show_settings_dialog.dart
@@ -494,11 +494,13 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                                 _saveToggleStates();
                               },
                               '''
+
                               **Cleanse Toggle:** \n
                               Cleansing prepares the dataset by: \n
                               - Removing columns with a single constant value.\n
                               - Converting character columns with limited unique values to categoric factors. \n
                               Enable for automated cleansing, or disable if not required.
+                              
                               ''',
                             ),
                           ),
@@ -512,11 +514,13 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                                 _saveToggleStates();
                               },
                               '''
+
                               **Unify Toggle:** \n
                               Unifies dataset column names by:\n
                               - Converting names to lowercase.\n
                               - Replacing spaces with underscores. \n
                               Enable for consistent formatting, or disable if original names are preferred.
+
                               ''',
                             ),
                           ),
@@ -530,20 +534,24 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                                 _saveToggleStates();
                               },
                               '''
+
                               **Partition Toggle:** \n
                               Splits the dataset into subsets for predictive modeling:\n
                               - **Training:** Builds the model.\n
                               - **Validation:** Tunes the model.\n
                               - **Testing:** Evaluates model performance. \n
                               Enable for larger datasets, or disable for exploratory analysis.
+
                               ''',
                             ),
                           ),
                           MarkdownTooltip(
                             message: '''
+
                             **Keep in Sync Toggle:** \n
                             - **On:** Saves toggle changes for current sessions. \n
                             - **Off:** Changes are only recovered on restart.
+
                             ''',
                             child: const Text(
                               'Keep in Sync',
@@ -552,9 +560,11 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                           ),
                           MarkdownTooltip(
                             message: '''
+
                             **Keep in Sync Toggle:** \n
                             - **On:** Saves toggle changes for current sessions. \n
                             - **Off:** Changes are only recovered on restart.
+
                             ''',
                             child: Switch(
                               value: keepInSync,
@@ -695,10 +705,10 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                           MarkdownTooltip(
                             message: '''
 
-                          **Reset Image Viewer App:** Tap here to reset the Image Viewer App setting
-                          to the platform's default ("open" on Linux/MacOS, "start" on Windows).
+                            **Reset Image Viewer App:** Tap here to reset the Image Viewer App setting
+                            to the platform's default ("open" on Linux/MacOS, "start" on Windows).
 
-                          ''',
+                            ''',
                             child: ElevatedButton(
                               onPressed: () {
                                 final defaultApp =
@@ -731,12 +741,14 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                         children: [
                           MarkdownTooltip(
                             message: '''
+
                             **Random Seed Setting:** 
                             The random seed is used to control the randomness. 
                             Setting a specific seed ensures that results are reproducible.
 
                             - **Default Seed:** The default seed is 42.
                             - **Reset:** Use the "Reset" button to restore the default seed.
+
                             ''',
                             child: const Text(
                               'Random Seed',
@@ -749,9 +761,11 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                           configRowGap,
                           MarkdownTooltip(
                             message: '''
+
                             **Reset Random Seed:** 
                             Clicking this button resets the random seed to the default value of 42.
                             This is useful if you want to restore the initial random state.
+
                             ''',
                             child: ElevatedButton(
                               onPressed: () {


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- SETTINGS: DataSet Toggles toggle widgets and their text each need a MarkdownTooltip #627


- Link to associated issue: #627 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [x] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
