### PR TITLE
kev/604_reset_first_feature

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -43,6 +43,7 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:markdown_tooltip/markdown_tooltip.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:rattle/providers/reset.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -339,6 +340,10 @@ Xu, Yixiang Yin, Bo Zhang.
                 color: Colors.blue,
               ),
               onPressed: () async {
+                // Set isResetProvider to true
+
+                ref.read(isResetProvider.notifier).state = true;
+
                 // TODO yyx 20240611 return focus to DATASET TAB and set the sub tabs to the first tabs (put it in reset)
                 if (ref.read(datasetLoaded)) {
                   showDatasetAlertDialog(context, ref, false);

--- a/lib/providers/reset.dart
+++ b/lib/providers/reset.dart
@@ -1,0 +1,28 @@
+///  This file contains the provider for the reset button.
+///
+/// Copyright (C) 2024, Togaware Pty Ltd.
+///
+/// License: GNU General Public License, Version 3 (the "License")
+/// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// Time-stamp: <Sunday 2024-06-02 14:56:17 +1000 Graham Williams>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Kevin Wang
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final isResetProvider = StateProvider<bool>((ref) => false);

--- a/lib/r/source.dart
+++ b/lib/r/source.dart
@@ -381,8 +381,6 @@ Future<void> rSource(
 
   code = code.replaceAll('SELECTED_2_VAR', selected2);
 
-  //TODO kevin
-
   code = code.replaceAll('GROUP_BY_VAR', groupBy == 'None' ? 'NULL' : groupBy);
 
   code = code.replaceAll('IMPUTED_VALUE', imputed);

--- a/lib/tabs/explore.dart
+++ b/lib/tabs/explore.dart
@@ -39,6 +39,7 @@ import 'package:rattle/features/tests/panel.dart';
 import 'package:rattle/features/interactive/panel.dart';
 import 'package:rattle/providers/datatype.dart';
 import 'package:rattle/providers/explore.dart';
+import 'package:rattle/providers/reset.dart';
 import 'package:rattle/utils/debug_text.dart';
 
 final List<Map<String, dynamic>> explorePanels = [
@@ -84,6 +85,8 @@ class ExploreTabs extends ConsumerStatefulWidget {
   ConsumerState<ExploreTabs> createState() => _ExploreTabsState();
 }
 
+//TODO kevin
+
 class _ExploreTabsState extends ConsumerState<ExploreTabs>
     with AutomaticKeepAliveClientMixin, SingleTickerProviderStateMixin {
   late TabController _tabController;
@@ -109,6 +112,19 @@ class _ExploreTabsState extends ConsumerState<ExploreTabs>
   Widget build(BuildContext context) {
     super.build(context);
     debugText('  BUILD', 'ExploreTab');
+
+    // Listen to isResetProvider and reset tabController to index 0 if true.
+
+    final isReset = ref.watch(isResetProvider);
+
+    if (isReset) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _tabController.animateTo(0);
+        // Reset the flag.
+
+        ref.read(isResetProvider.notifier).state = false;
+      });
+    }
 
     return Column(
       children: [

--- a/lib/tabs/explore.dart
+++ b/lib/tabs/explore.dart
@@ -85,8 +85,6 @@ class ExploreTabs extends ConsumerStatefulWidget {
   ConsumerState<ExploreTabs> createState() => _ExploreTabsState();
 }
 
-//TODO kevin
-
 class _ExploreTabsState extends ConsumerState<ExploreTabs>
     with AutomaticKeepAliveClientMixin, SingleTickerProviderStateMixin {
   late TabController _tabController;

--- a/lib/tabs/model.dart
+++ b/lib/tabs/model.dart
@@ -44,6 +44,7 @@ import 'package:rattle/features/wordcloud/panel.dart';
 import 'package:rattle/providers/datatype.dart';
 import 'package:rattle/providers/model.dart';
 import 'package:rattle/providers/path.dart';
+import 'package:rattle/providers/reset.dart';
 import 'package:rattle/utils/debug_text.dart';
 
 final List<Map<String, dynamic>> modelPanels = [
@@ -145,6 +146,19 @@ class _ModelTabsState extends ConsumerState<ModelTabs>
     super.build(context);
     debugText('  BUILD', 'ModelTabs');
     debugPrint(ref.read(pathProvider));
+
+    // Listen to isResetProvider and reset tabController to index 0 if true.
+
+    final isReset = ref.watch(isResetProvider);
+
+    if (isReset) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _tabController.animateTo(0);
+        // Reset the flag.
+
+        ref.read(isResetProvider.notifier).state = false;
+      });
+    }
 
     return Column(
       children: [

--- a/lib/tabs/transform.dart
+++ b/lib/tabs/transform.dart
@@ -37,6 +37,7 @@ import 'package:rattle/features/recode/panel.dart';
 import 'package:rattle/features/cleanup/panel.dart';
 import 'package:rattle/providers/datatype.dart';
 import 'package:rattle/providers/transform.dart';
+import 'package:rattle/providers/reset.dart';
 import 'package:rattle/utils/debug_text.dart';
 
 final List<Map<String, dynamic>> transformPanels = [
@@ -94,6 +95,19 @@ class _TransformTabsState extends ConsumerState<TransformTabs>
   Widget build(BuildContext context) {
     super.build(context);
     debugText('  BUILD', 'TransformTab');
+
+    // Listen to isResetProvider and reset tabController to index 0 if true.
+
+    final isReset = ref.watch(isResetProvider);
+
+    if (isReset) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _tabController.animateTo(0);
+        // Reset the flag.
+
+        ref.read(isResetProvider.notifier).state = false;
+      });
+    }
 
     return Column(
       children: [


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- RESET: On a reset/loading new dataset, reset all tabs to the first feature

- Link to associated issue: #604 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
