### PR TITLE
Kev/689_toggle_randomise_partitioning

### DIFF
--- a/lib/providers/settings.dart
+++ b/lib/providers/settings.dart
@@ -74,3 +74,5 @@ final settingsGraphicThemeProvider =
 final randomSeedSettingProvider = StateProvider<int>((ref) => 42);
 
 final imageViewerSettingProvider = StateProvider<String>((ref) => '');
+
+final ramdomPartitionSettingProvider = StateProvider<bool>((ref) => false);

--- a/lib/providers/settings.dart
+++ b/lib/providers/settings.dart
@@ -75,4 +75,4 @@ final randomSeedSettingProvider = StateProvider<int>((ref) => 42);
 
 final imageViewerSettingProvider = StateProvider<String>((ref) => '');
 
-final ramdomPartitionSettingProvider = StateProvider<bool>((ref) => false);
+final randomPartitionSettingProvider = StateProvider<bool>((ref) => false);

--- a/lib/r/source.dart
+++ b/lib/r/source.dart
@@ -104,6 +104,7 @@ Future<void> rSource(
   // Initialise the state variables obtained from the different providers.
 
   int randomSeedSetting = ref.read(randomSeedSettingProvider);
+  bool randomPartitionSetting = ref.read(randomPartitionSettingProvider);
 
   bool checkbox = ref.read(checkboxProvider);
   bool cleanse = ref.read(cleanseProvider);
@@ -303,7 +304,8 @@ Future<void> rSource(
 
   code = code.replaceAll('MAXFACTOR', '20');
 
-  code = code.replaceAll('RANDOM_PARTITION', 'FALSE');
+  code = code.replaceAll(
+      'RANDOM_PARTITION', randomPartitionSetting.toString().toUpperCase());
   code = code.replaceAll('RANDOM_SEED', randomSeedSetting.toString());
 
   code = code.replaceAll('SETTINGS_GRAPHIC_THEME', theme);

--- a/lib/r/source.dart
+++ b/lib/r/source.dart
@@ -305,7 +305,9 @@ Future<void> rSource(
   code = code.replaceAll('MAXFACTOR', '20');
 
   code = code.replaceAll(
-      'RANDOM_PARTITION', randomPartitionSetting.toString().toUpperCase());
+    'RANDOM_PARTITION',
+    randomPartitionSetting.toString().toUpperCase(),
+  );
   code = code.replaceAll('RANDOM_SEED', randomSeedSetting.toString());
 
   code = code.replaceAll('SETTINGS_GRAPHIC_THEME', theme);

--- a/lib/utils/show_settings_dialog.dart
+++ b/lib/utils/show_settings_dialog.dart
@@ -802,6 +802,13 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                                     .read(randomSeedSettingProvider.notifier)
                                     .state = 42;
                                 _saveRandomSeed(42);
+
+                                ref
+                                    .read(
+                                      randomPartitionSettingProvider.notifier,
+                                    )
+                                    .state = false;
+                                _saveRandomPartition(false);
                               },
                               child: const Text('Reset'),
                             ),
@@ -845,7 +852,8 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                               onChanged: (value) {
                                 ref
                                     .read(
-                                        randomPartitionSettingProvider.notifier)
+                                      randomPartitionSettingProvider.notifier,
+                                    )
                                     .state = value;
                                 _saveRandomPartition(value);
                               },

--- a/lib/utils/show_settings_dialog.dart
+++ b/lib/utils/show_settings_dialog.dart
@@ -273,6 +273,9 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
 
     ref.read(imageViewerSettingProvider.notifier).state =
         prefs.getString('imageViewerApp') ?? platformDefault;
+
+    ref.read(randomPartitionSettingProvider.notifier).state =
+        prefs.getBool('randomPartition') ?? false;
   }
 
   Future<void> _saveToggleStates() async {
@@ -315,6 +318,14 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
     // Save "Keep in Sync" state to preferences.
 
     await prefs.setBool('keepInSync', value);
+  }
+
+  Future<void> _saveRandomPartition(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    // Save "Random Partition" state to preferences.
+
+    await prefs.setBool('randomPartition', value);
   }
 
   Future<void> _saveAskOnExit(bool value) async {
@@ -397,6 +408,7 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
     final askOnExit = ref.watch(askOnExitProvider);
 
     final randomSeed = ref.watch(randomSeedSettingProvider);
+    final randomPartition = ref.watch(randomPartitionSettingProvider);
 
     return Material(
       color: Colors.transparent,
@@ -799,13 +811,47 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
 
                       configRowGap,
 
-                      RandomSeedRow(
-                        randomSeed: randomSeed,
-                        updateSeed: (newSeed) {
-                          ref.read(randomSeedSettingProvider.notifier).state =
-                              newSeed;
-                          _saveRandomSeed(newSeed);
-                        },
+                      Row(
+                        spacing: 10,
+                        children: [
+                          RandomSeedRow(
+                            randomSeed: randomSeed,
+                            updateSeed: (newSeed) {
+                              ref
+                                  .read(randomSeedSettingProvider.notifier)
+                                  .state = newSeed;
+                              _saveRandomSeed(newSeed);
+                            },
+                          ),
+                          MarkdownTooltip(
+                            message: '''
+
+         
+
+                            ''',
+                            child: const Text(
+                              'Random Partition each Model Build',
+                              style: TextStyle(fontSize: 16),
+                            ),
+                          ),
+                          MarkdownTooltip(
+                            message: '''
+
+           
+
+                            ''',
+                            child: Switch(
+                              value: randomPartition,
+                              onChanged: (value) {
+                                ref
+                                    .read(
+                                        randomPartitionSettingProvider.notifier)
+                                    .state = value;
+                                _saveRandomPartition(value);
+                              },
+                            ),
+                          ),
+                        ],
                       ),
 
                       settingsGroupGap,


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

-SETTINGS: Add a toggle to always randomise paritioning for RANDOM_PARTITION template variable 


- Link to associated issue: #689 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
