### PR TITLE
kev/703_move_scroll_bar_far_right

### DIFF
--- a/lib/providers/settings.dart
+++ b/lib/providers/settings.dart
@@ -75,7 +75,6 @@ final randomSeedSettingProvider = StateProvider<int>((ref) => 42);
 
 final imageViewerSettingProvider = StateProvider<String>((ref) => '');
 
-
 final randomPartitionSettingProvider = StateProvider<bool>((ref) => false);
 
 final rExecutablePathProvider = StateProvider<String>((ref) => '');

--- a/lib/tabs/script/text.dart
+++ b/lib/tabs/script/text.dart
@@ -42,24 +42,40 @@ class ScriptText extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Create a ScrollController for scrolling.
+
+    final ScrollController scrollController = ScrollController();
+
     // Build the widget.
 
     return Container(
       color: Colors.white,
       child: Stack(
         children: [
-          // Main content with scrollable text
-          SingleChildScrollView(
-            child: Builder(
-              builder: (BuildContext context) {
-                final script = ref.watch(scriptProvider);
+          // Main content with scrollable text.
 
-                return SelectableText(
-                  script,
-                  key: scriptTextKey,
-                  style: monoSmallTextStyle,
-                );
-              },
+          Scrollbar(
+            controller: scrollController,
+            thumbVisibility: true,
+            child: SingleChildScrollView(
+              controller: scrollController,
+              scrollDirection: Axis.vertical,
+              child: Builder(
+                builder: (BuildContext context) {
+                  final script = ref.watch(scriptProvider);
+
+                  return Container(
+                    // Ensure width matches the full container.
+
+                    width: MediaQuery.of(context).size.width,
+                    child: SelectableText(
+                      script,
+                      key: scriptTextKey,
+                      style: monoSmallTextStyle,
+                    ),
+                  );
+                },
+              ),
             ),
           ),
           // ScriptSaveButton at the top-right corner.


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- SCRIPTS: Move the scroll bar to the far right 



- Link to associated issue: #703 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
