### PR TITLE
kev/713_reset_provider

### DIFF
--- a/lib/providers/keep_in_sync.dart
+++ b/lib/providers/keep_in_sync.dart
@@ -25,4 +25,4 @@ library;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final keepInSyncProvider = StateProvider<bool>((ref) => true);
+final keepInSyncProvider = StateProvider<bool>((ref) => false);

--- a/lib/utils/show_settings_dialog.dart
+++ b/lib/utils/show_settings_dialog.dart
@@ -302,11 +302,10 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
   void _resetToggleStates() {
     // Reset all toggles to default.
 
-    ref.read(cleanseProvider.notifier).state = true;
-    ref.read(normaliseProvider.notifier).state = true;
-    ref.read(partitionProvider.notifier).state = true;
-
-    ref.read(keepInSyncProvider.notifier).state = false;
+    ref.invalidate(cleanseProvider);
+    ref.invalidate(normaliseProvider);
+    ref.invalidate(partitionProvider);
+    ref.invalidate(keepInSyncProvider);
 
     // Save the reset states to preferences.
 
@@ -316,7 +315,7 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
   void resetSessionControl() {
     // Reset session control to default.
 
-    ref.read(askOnExitProvider.notifier).state = true;
+    ref.invalidate(askOnExitProvider);
 
     // Save the reset state to preferences.
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- RESET: When resetting a provider use ref.invalidate()


- Link to associated issue: #713 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
