### PR TITLE
kev/720_reset_useValidation_bug

### DIFF
--- a/lib/utils/show_settings_dialog.dart
+++ b/lib/utils/show_settings_dialog.dart
@@ -344,6 +344,12 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
     // Save "Validation than Tuning" state to preferences.
 
     await prefs.setBool('useValidation', value);
+
+    // If the value is false, invalidate the provider to reset the partition values.
+
+    if (!value) {
+      ref.invalidate(useValidationSettingProvider);
+    }
   }
 
   Future<void> _saveAskOnExit(bool value) async {
@@ -871,10 +877,6 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                             ''',
                             child: ElevatedButton(
                               onPressed: () async {
-                                ref.invalidate(
-                                  useValidationSettingProvider,
-                                );
-
                                 // Reset the partition values to default.  Save
                                 // the new values to shared preferences and
                                 // providers.
@@ -882,6 +884,8 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
                                 await _savePartitionTrain(70);
                                 await _savePartitionTune(15);
                                 await _savePartitionTest(15);
+
+                                _saveValidation(false);
                               },
                               child: const Text('Reset'),
                             ),


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- SETTINGS: A RESET of useValidation is not retained across sessions 


- Link to associated issue: #720 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
