### PR TITLE
kev/743_app_default_set_once

### DIFF
--- a/lib/providers/settings.dart
+++ b/lib/providers/settings.dart
@@ -25,6 +25,8 @@
 
 library;
 
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -73,7 +75,8 @@ final settingsGraphicThemeProvider =
 
 final randomSeedSettingProvider = StateProvider<int>((ref) => 42);
 
-final imageViewerSettingProvider = StateProvider<String>((ref) => '');
+final imageViewerSettingProvider =
+    StateProvider<String>((ref) => Platform.isWindows ? 'start' : 'open');
 
 final randomPartitionSettingProvider = StateProvider<bool>((ref) => false);
 

--- a/lib/settings/widgets/image_viewer_text_field.dart
+++ b/lib/settings/widgets/image_viewer_text_field.dart
@@ -1,6 +1,6 @@
 /// Image viewer text field.
 //
-// Time-stamp: <Monday 2025-01-06 15:20:25 +1100 Graham Williams>
+// Time-stamp: <Monday 2025-01-13 16:17:39 +1100 Graham Williams>
 //
 /// Copyright (C) 2024, Togaware Pty Ltd
 ///
@@ -48,8 +48,10 @@ class ImageViewerTextField extends ConsumerWidget {
       message: '''
 
       **Image Viewer Application Setting:** This setting determines the default
-      command to open image files. The default is "open" on Linux/MacOS and "start"
-      on Windows. You can customise it to match your preferred image viewer.
+      command to open image files. The default is "open" on Linux/MacOS and
+      "start" on Windows. You can customise it to match your preferred image
+      viewer. A good choice is **inkscape** which will allow editting the plot
+      as a native SVG.
 
       ''',
       child: Row(

--- a/lib/settings/widgets/section_session.dart
+++ b/lib/settings/widgets/section_session.dart
@@ -46,12 +46,21 @@ class Session extends ConsumerWidget {
 
   /// Reset session control settings
   void resetSessionControl(WidgetRef ref) {
+    // Reset the ask on exit setting.
+
     ref.invalidate(askOnExitProvider);
+
+    // Save the ask on exit setting to shared_preferences.
+
     saveAskOnExit(true);
 
-    final defaultApp = Platform.isWindows ? 'start' : 'open';
-    ref.read(imageViewerSettingProvider.notifier).state = defaultApp;
-    saveImageViewerApp(defaultApp);
+    // Reset the image viewer app setting.
+
+    ref.invalidate(imageViewerSettingProvider);
+
+    // Save the image viewer app setting to shared_preferences.
+
+    saveImageViewerApp(ref.read(imageViewerSettingProvider));
   }
 
   @override

--- a/lib/settings/widgets/section_session.dart
+++ b/lib/settings/widgets/section_session.dart
@@ -22,7 +22,6 @@
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
 /// Authors: Kevin Wang
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- the app default should be set once in the provider defintion

- Link to associated issue: #743 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
