### PR TITLE
zy/763 Tuning default

### DIFF
--- a/lib/providers/evaluate.dart
+++ b/lib/providers/evaluate.dart
@@ -35,7 +35,8 @@ final boostEvaluateProvider = StateProvider<bool>((ref) => false);
 final conditionalForestEvaluateProvider = StateProvider<bool>((ref) => false);
 final cTreeEvaluateProvider = StateProvider<bool>((ref) => false);
 final datasetTypeProvider = StateProvider<String>(
-    (ref) => ref.watch(useValidationSettingProvider) ? 'Validation' : 'Tuning',);
+  (ref) => ref.watch(useValidationSettingProvider) ? 'Validation' : 'Tuning',
+);
 final forestEvaluateProvider = StateProvider<bool>((ref) => false);
 final hClusterEvaluateProvider = StateProvider<bool>((ref) => false);
 final kMeansEvaluateProvider = StateProvider<bool>((ref) => false);

--- a/lib/providers/evaluate.dart
+++ b/lib/providers/evaluate.dart
@@ -32,7 +32,7 @@ final adaBoostEvaluateProvider = StateProvider<bool>((ref) => false);
 final boostEvaluateProvider = StateProvider<bool>((ref) => false);
 final conditionalForestEvaluateProvider = StateProvider<bool>((ref) => false);
 final cTreeEvaluateProvider = StateProvider<bool>((ref) => false);
-final datasetTypeProvider = StateProvider<String>((ref) => 'Training');
+final datasetTypeProvider = StateProvider<String>((ref) => 'Tuning');
 final forestEvaluateProvider = StateProvider<bool>((ref) => false);
 final hClusterEvaluateProvider = StateProvider<bool>((ref) => false);
 final kMeansEvaluateProvider = StateProvider<bool>((ref) => false);

--- a/lib/providers/evaluate.dart
+++ b/lib/providers/evaluate.dart
@@ -28,11 +28,14 @@ library;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:rattle/providers/settings.dart';
+
 final adaBoostEvaluateProvider = StateProvider<bool>((ref) => false);
 final boostEvaluateProvider = StateProvider<bool>((ref) => false);
 final conditionalForestEvaluateProvider = StateProvider<bool>((ref) => false);
 final cTreeEvaluateProvider = StateProvider<bool>((ref) => false);
-final datasetTypeProvider = StateProvider<String>((ref) => 'Tuning');
+final datasetTypeProvider = StateProvider<String>(
+    (ref) => ref.watch(useValidationSettingProvider) ? 'Validation' : 'Tuning',);
 final forestEvaluateProvider = StateProvider<bool>((ref) => false);
 final hClusterEvaluateProvider = StateProvider<bool>((ref) => false);
 final kMeansEvaluateProvider = StateProvider<bool>((ref) => false);


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- EVALUATE: Make Tuning the default rather than Training

- Link to associated issue: #763 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [ ] Added two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
