### PR TITLE
kev/850_Swap_the_NeuralNet_and_NNet_chips

### DIFF
--- a/lib/features/neural/config.dart
+++ b/lib/features/neural/config.dart
@@ -55,16 +55,16 @@ class NeuralConfig extends ConsumerStatefulWidget {
 
 class NeuralConfigState extends ConsumerState<NeuralConfig> {
   Map<String, String> neuralAlgorithm = {
-    'nnet': '''
-
-    A basic neural network with a single hidden layer.
-    Suitable for simple tasks and small datasets.
-
-    ''',
     'neuralnet': '''
 
     Supports multiple layers, ideal for complex patterns.
     Commonly used for deeper architectures.
+
+    ''',
+    'nnet': '''
+
+    A basic neural network with a single hidden layer.
+    Suitable for simple tasks and small datasets.
 
     ''',
   };

--- a/lib/providers/neural.dart
+++ b/lib/providers/neural.dart
@@ -31,7 +31,7 @@ library;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final activationFctNeuralProvider = StateProvider<String>((ref) => 'logistic');
-final algorithmNeuralProvider = StateProvider<String>((ref) => 'nnet');
+final algorithmNeuralProvider = StateProvider<String>((ref) => 'neuralnet');
 final errorFctNeuralProvider = StateProvider<String>((ref) => 'sse');
 final hiddenLayersNeuralProvider = StateProvider<String>((ref) => '10');
 final ignoreCategoricNeuralProvider = StateProvider<bool>((ref) => true);


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- NEURAL: Swap the NeuralNet and NNet chips so NeuralNet is the default 


- Link to associated issue: #850 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
