### PR TITLE
kev/898_settings_partition_immediate_effect

### DIFF
--- a/lib/r/source.dart
+++ b/lib/r/source.dart
@@ -1,6 +1,6 @@
 /// Support for running an R script using R source().
 ///
-// Time-stamp: <Friday 2025-02-07 05:21:20 +1100 Graham Williams>
+// Time-stamp: <Thursday 2025-02-13 14:40:26 +1100 Graham Williams>
 ///
 /// Copyright (C) 2023-2025, Togaware Pty Ltd.
 ///
@@ -104,16 +104,22 @@ Future<void> rSource(
   WidgetRef ref,
   List<String> scripts,
 ) async {
-  // Load the partition train value from shared preferences and update the provider.
-  // So that the values are immediately available on startup.
+  // 20250213 gjw Be sure to load the partition informationfrom shared
+  // preferences and so update the provider appropraitely so that the user's
+  // selected preferred partitioning is immediately available on startup.
 
   final prefs = await SharedPreferences.getInstance();
-  final trainValue = prefs.getInt('train') ?? 60;
+
+  final trainValue =
+      prefs.getInt('train') ?? ref.read(partitionTrainProvider.notifier).state;
   ref.read(partitionTrainProvider.notifier).state = trainValue;
-  final tuneValue = prefs.getInt('tune') ?? 15;
+
+  final tuneValue =
+      prefs.getInt('tune') ?? ref.read(partitionTuneProvider.notifier).state;
   ref.read(partitionTuneProvider.notifier).state = tuneValue;
 
-  final testValue = prefs.getInt('test') ?? 25;
+  final testValue =
+      prefs.getInt('test') ?? ref.read(partitionTestProvider.notifier).state;
   ref.read(partitionTestProvider.notifier).state = testValue;
 
   // Update the partition setting provider with the loaded values

--- a/lib/r/source.dart
+++ b/lib/r/source.dart
@@ -33,6 +33,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:rattle/providers/dataset.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:universal_io/io.dart' show Platform;
 
@@ -103,6 +104,25 @@ Future<void> rSource(
   WidgetRef ref,
   List<String> scripts,
 ) async {
+  // Load the partition train value from shared preferences and update the provider.
+  // So that the values are immediately available on startup.
+
+  final prefs = await SharedPreferences.getInstance();
+  final trainValue = prefs.getInt('train') ?? 60;
+  ref.read(partitionTrainProvider.notifier).state = trainValue;
+  final tuneValue = prefs.getInt('tune') ?? 15;
+  ref.read(partitionTuneProvider.notifier).state = tuneValue;
+
+  final testValue = prefs.getInt('test') ?? 25;
+  ref.read(partitionTestProvider.notifier).state = testValue;
+
+  // Update the partition setting provider with the loaded values
+  ref.read(partitionSettingProvider.notifier).state = [
+    trainValue / 100,
+    tuneValue / 100,
+    testValue / 100,
+  ];
+
   // Initialise the state variables obtained from the different providers.
 
   // TODO 20250131 gjw MIGRATE TO NOT CACHE THE VALUES HERE

--- a/lib/settings/sections/partition.dart
+++ b/lib/settings/sections/partition.dart
@@ -44,6 +44,8 @@ class Partition extends ConsumerWidget {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setInt('train', value);
       ref.read(partitionTrainProvider.notifier).state = value;
+      // Save the new partition ratios to the partition setting provider to have immediate effect.
+
       ref.read(partitionSettingProvider.notifier).state = [
         value / 100,
         ref.read(partitionTuneProvider) / 100,
@@ -55,6 +57,8 @@ class Partition extends ConsumerWidget {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setInt('tune', value);
       ref.read(partitionTuneProvider.notifier).state = value;
+      // Save the new partition ratios to the partition setting provider to have immediate effect.
+
       ref.read(partitionSettingProvider.notifier).state = [
         ref.read(partitionTrainProvider) / 100,
         value / 100,
@@ -66,6 +70,8 @@ class Partition extends ConsumerWidget {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setInt('test', value);
       ref.read(partitionTestProvider.notifier).state = value;
+      // Save the new partition ratios to the partition setting provider to have immediate effect.
+
       ref.read(partitionSettingProvider.notifier).state = [
         ref.read(partitionTrainProvider) / 100,
         ref.read(partitionTuneProvider) / 100,

--- a/lib/settings/sections/partition.dart
+++ b/lib/settings/sections/partition.dart
@@ -44,18 +44,33 @@ class Partition extends ConsumerWidget {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setInt('train', value);
       ref.read(partitionTrainProvider.notifier).state = value;
+      ref.read(partitionSettingProvider.notifier).state = [
+        value / 100,
+        ref.read(partitionTuneProvider) / 100,
+        ref.read(partitionTestProvider) / 100,
+      ];
     }
 
     Future<void> _savePartitionTune(int value) async {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setInt('tune', value);
       ref.read(partitionTuneProvider.notifier).state = value;
+      ref.read(partitionSettingProvider.notifier).state = [
+        ref.read(partitionTrainProvider) / 100,
+        value / 100,
+        ref.read(partitionTestProvider) / 100,
+      ];
     }
 
     Future<void> _savePartitionTest(int value) async {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setInt('test', value);
       ref.read(partitionTestProvider.notifier).state = value;
+      ref.read(partitionSettingProvider.notifier).state = [
+        ref.read(partitionTrainProvider) / 100,
+        ref.read(partitionTuneProvider) / 100,
+        value / 100,
+      ];
     }
 
     Future<void> _saveValidation(bool value) async {


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- SETTINGS: The partition string does not have immediate effect 

- Link to associated issue: #898 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
