### PR TITLE
kev/904_image_viewer_bug

### DIFF
--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -257,11 +257,16 @@ class ImagePage extends ConsumerWidget {
 
                             File(path).copy(tempFile.path);
 
-                            // Get the image viewer app from SharedPreferences or fall back to provider.
+                            // Get the image viewer app from SharedPreferences or use the provider default
+                            // if not set.
 
                             final prefs = await SharedPreferences.getInstance();
                             final savedImageViewer =
                                 prefs.getString('imageViewerApp');
+
+                            // If the shared preferences image viewer app is null(not set),
+                            // use the provider default.
+
                             final imageViewerApp = savedImageViewer ??
                                 ref.read(imageViewerSettingProvider);
 

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -37,6 +37,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:markdown_tooltip/markdown_tooltip.dart';
@@ -50,8 +51,9 @@ import 'package:rattle/utils/debug_text.dart';
 import 'package:rattle/utils/select_file.dart';
 import 'package:rattle/utils/show_image_dialog.dart';
 import 'package:rattle/utils/show_ok.dart';
+import 'package:rattle/providers/settings.dart';
 
-class ImagePage extends StatelessWidget {
+class ImagePage extends ConsumerWidget {
   final String title;
   final String path;
 
@@ -152,7 +154,7 @@ class ImagePage extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     debugText('  IMAGE', path);
 
     // Clear the image cache
@@ -252,17 +254,16 @@ class ImagePage extends StatelessWidget {
                             File tempFile = File('$tempDir/$fileName');
 
                             // Copy the original file to the temporary file.
+
                             File(path).copy(tempFile.path);
 
-                            // Pop out a window to display the plot separate
-                            // to the Rattle app.
-
-                            // Update "Image Viewer" state.
+                            // Get the image viewer app from SharedPreferences or fall back to provider.
 
                             final prefs = await SharedPreferences.getInstance();
-
-                            final imageViewerApp =
+                            final savedImageViewer =
                                 prefs.getString('imageViewerApp');
+                            final imageViewerApp = savedImageViewer ??
+                                ref.read(imageViewerSettingProvider);
 
                             Platform.isWindows
                                 ? Process.run(


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- IMAGE PAGE: Default imageViewerApp is null if not set in SETTINGS 

- Link to associated issue: #904 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
- [ ] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
