### PR TITLE
zy/930 fix multi_image_page

### DIFF
--- a/lib/widgets/multi_image_page.dart
+++ b/lib/widgets/multi_image_page.dart
@@ -290,7 +290,8 @@ class MultiImagePage extends ConsumerWidget {
                                         final imageViewerApp =
                                             savedImageViewer ??
                                                 ref.read(
-                                                    imageViewerSettingProvider,);
+                                                  imageViewerSettingProvider,
+                                                );
 
                                         Platform.isWindows
                                             ? Process.run(

--- a/lib/widgets/multi_image_page.dart
+++ b/lib/widgets/multi_image_page.dart
@@ -290,7 +290,7 @@ class MultiImagePage extends ConsumerWidget {
                                         final imageViewerApp =
                                             savedImageViewer ??
                                                 ref.read(
-                                                    imageViewerSettingProvider);
+                                                    imageViewerSettingProvider,);
 
                                         Platform.isWindows
                                             ? Process.run(

--- a/lib/widgets/multi_image_page.dart
+++ b/lib/widgets/multi_image_page.dart
@@ -28,25 +28,26 @@ library;
 import 'dart:io';
 import 'dart:async';
 import 'dart:math';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:markdown_tooltip/markdown_tooltip.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'package:rattle/providers/settings.dart';
 import 'package:rattle/constants/temp_dir.dart';
 import 'package:rattle/utils/select_file.dart';
 import 'package:rattle/utils/show_image_dialog.dart';
 import 'package:rattle/utils/show_ok.dart';
 
-class MultiImagePage extends StatelessWidget {
+class MultiImagePage extends ConsumerWidget {
   final List<String> titles;
   final List<String> paths;
   final String pageTitle;
@@ -137,7 +138,7 @@ class MultiImagePage extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     imageCache.clear();
     imageCache.clearLiveImages();
     final ScrollController _scrollController = ScrollController();
@@ -280,8 +281,16 @@ class MultiImagePage extends StatelessWidget {
 
                                         final prefs = await SharedPreferences
                                             .getInstance();
-                                        final imageViewerApp =
+                                        final savedImageViewer =
                                             prefs.getString('imageViewerApp');
+
+                                        // If the shared preferences image viewer app is null(not set),
+                                        // use the provider default.
+
+                                        final imageViewerApp =
+                                            savedImageViewer ??
+                                                ref.read(
+                                                    imageViewerSettingProvider);
 
                                         Platform.isWindows
                                             ? Process.run(


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- BUG: Multiple image plot OPEN fails

- Link to associated issue: #930 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
