### PR TITLE
Zy/985 bug max factor settings openned

### DIFF
--- a/lib/providers/cleanse.dart
+++ b/lib/providers/cleanse.dart
@@ -25,11 +25,31 @@
 library;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Whether to cleanse the data or not. Default is true.
 
 final cleanseProvider = StateProvider<bool>((ref) => true);
 
 /// The maximum number of unique values for a character column to be a factor.
+/// This provider is initially set to 20, and then updated asynchronously with
+/// the saved value from SharedPreferences if available.
 
-final maxFactorProvider = StateProvider<int>((ref) => 20);
+final StateProvider<int> maxFactorProvider = StateProvider<int>((ref) {
+  const int defaultValue = 20;
+
+  // Schedule a microtask to load the saved value from SharedPreferences.
+
+  Future.microtask(() async {
+    final prefs = await SharedPreferences.getInstance();
+    final storedValue = prefs.getInt('maxFactor') ?? defaultValue;
+
+    // Update the provider only if the stored value is different.
+
+    if (ref.read(maxFactorProvider.notifier).state != storedValue) {
+      ref.read(maxFactorProvider.notifier).state = storedValue;
+    }
+  });
+
+  return defaultValue;
+});

--- a/lib/settings/dialog.dart
+++ b/lib/settings/dialog.dart
@@ -134,7 +134,7 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
     // Max factor.
 
     ref.read(maxFactorProvider.notifier).state =
-        prefs.getInt('maxFactor') ?? 15;
+        prefs.getInt('maxFactor') ?? 20;
 
     // Partition ratios.
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

-BUG: Max Factor only has effect if SETTINGS openned first

- Link to associated issue: #985

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [ ] Changes adhere to the style and coding guideline
- [ ] No confidential information
- [ ] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [ ] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
- [ ] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
