### PR TITLE
zy/ fix conflict between dart_code_metrics and import_order_lint.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,11 +12,14 @@
 analyzer:
   plugins:
     - custom_lint
-  custom_lint:
-    rules:
-      - import-order_lint
   exclude:
     - ignore/**
+
+# Custom lint configuration
+
+custom_lint:
+  rules:
+    - import-order_lint
 
 dart_code_metrics:
 #  anti-patterns:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -112,6 +112,7 @@ dev_dependencies:
 
 dependency_overrides:
   collection: ^1.19.0  # Required for dart-code-metrics.
+  analyzer: ^6.8.0     # Override to resolve conflict between dart_code_metrics and import_order_lint.
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,7 +103,7 @@ dev_dependencies:
   dart_code_metrics:
     git:
       url: https://github.com/anusii/dart-code-metrics.git
-      ref: dev
+      ref: main
 
   import_order_lint:
     git:


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- [A one line description of this PR]

- Link to associated issue: #

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [ ] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
