### PR TITLE
Zy/1028 cluster seed push random seed

### DIFF
--- a/lib/features/cluster/config.dart
+++ b/lib/features/cluster/config.dart
@@ -151,7 +151,6 @@ class ClusterConfigState extends ConsumerState<ClusterConfig> {
 
               ''',
               label: 'Re-Scale',
-              enabled: type != 'Hierarchical',
               provider: reScaleClusterProvider,
             ),
           ],

--- a/lib/features/dataset/toggles.dart
+++ b/lib/features/dataset/toggles.dart
@@ -96,6 +96,12 @@ class _DatasetTogglesState extends ConsumerState<DatasetToggles> {
 
       ref.read(partitionProvider.notifier).state =
           prefs.getBool('partition') ?? true;
+
+      // Set the initial state of the "Random Seed" toggle based on shared preferences,
+      // defaulting to [defaultRandomSeed] if no value is found.
+
+      ref.read(randomSeedSettingProvider.notifier).state =
+          prefs.getInt('randomSeed') ?? defaultRandomSeed;
     } else {
       // If this is not the first start and "Keep in Sync" is enabled.
 
@@ -118,6 +124,12 @@ class _DatasetTogglesState extends ConsumerState<DatasetToggles> {
 
         ref.read(partitionProvider.notifier).state =
             prefs.getBool('partition') ?? ref.read(partitionProvider);
+
+        // Set the initial state of the "Random Seed" toggle based on shared preferences,
+        // defaulting to [defaultRandomSeed] if no value is found.
+
+        ref.read(randomSeedSettingProvider.notifier).state =
+            prefs.getInt('randomSeed') ?? ref.read(randomSeedSettingProvider);
       }
     }
   }

--- a/lib/features/dataset/toggles.dart
+++ b/lib/features/dataset/toggles.dart
@@ -96,6 +96,12 @@ class _DatasetTogglesState extends ConsumerState<DatasetToggles> {
 
       ref.read(partitionProvider.notifier).state =
           prefs.getBool('partition') ?? true;
+
+      // Set the initial state of the "Random Seed" toggle based on shared preferences,
+      // defaulting to `true` if no value is found.
+
+      ref.read(randomSeedSettingProvider.notifier).state =
+          prefs.getInt('randomSeed') ?? defaultRandomSeed;
     } else {
       // If this is not the first start and "Keep in Sync" is enabled.
 
@@ -118,6 +124,12 @@ class _DatasetTogglesState extends ConsumerState<DatasetToggles> {
 
         ref.read(partitionProvider.notifier).state =
             prefs.getBool('partition') ?? ref.read(partitionProvider);
+
+        // Update the "Random Seed" toggle state to match the value in shared preferences,
+        // falling back to the current provider state if no value is found.
+
+        ref.read(randomSeedSettingProvider.notifier).state =
+            prefs.getInt('randomSeed') ?? ref.read(randomSeedSettingProvider);
       }
     }
   }

--- a/lib/features/dataset/toggles.dart
+++ b/lib/features/dataset/toggles.dart
@@ -96,12 +96,6 @@ class _DatasetTogglesState extends ConsumerState<DatasetToggles> {
 
       ref.read(partitionProvider.notifier).state =
           prefs.getBool('partition') ?? true;
-
-      // Set the initial state of the "Random Seed" toggle based on shared preferences,
-      // defaulting to `true` if no value is found.
-
-      ref.read(randomSeedSettingProvider.notifier).state =
-          prefs.getInt('randomSeed') ?? defaultRandomSeed;
     } else {
       // If this is not the first start and "Keep in Sync" is enabled.
 
@@ -124,12 +118,6 @@ class _DatasetTogglesState extends ConsumerState<DatasetToggles> {
 
         ref.read(partitionProvider.notifier).state =
             prefs.getBool('partition') ?? ref.read(partitionProvider);
-
-        // Update the "Random Seed" toggle state to match the value in shared preferences,
-        // falling back to the current provider state if no value is found.
-
-        ref.read(randomSeedSettingProvider.notifier).state =
-            prefs.getInt('randomSeed') ?? ref.read(randomSeedSettingProvider);
       }
     }
   }

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -669,6 +669,14 @@ Kevin Wang, Zheyuan Xu, Yixiang Yin, Bo Zhang.
                 color: Colors.blue,
               ),
               onPressed: () async {
+                // Save the current random seed to shared preferences before
+                // showing the settings dialog. This ensures that any changes
+                // made to the random seed in the dialog are properly persisted.
+
+                int randomSeed = ref.read(randomSeedSettingProvider);
+                final prefs = await SharedPreferences.getInstance();
+                prefs.setInt('randomSeed', randomSeed);
+
                 showSettingsDialog(context);
               },
             ),

--- a/lib/providers/settings.dart
+++ b/lib/providers/settings.dart
@@ -73,7 +73,12 @@ final settingsGraphicThemeProvider =
   (ref) => SettingsGraphicThemeNotifier(),
 );
 
-final randomSeedSettingProvider = StateProvider<int>((ref) => 42);
+// Define the default value as a constant.
+
+const int defaultRandomSeed = 42;
+
+final randomSeedSettingProvider =
+    StateProvider<int>((ref) => defaultRandomSeed);
 
 final imageViewerSettingProvider =
     StateProvider<String>((ref) => Platform.isWindows ? 'start' : 'open');

--- a/lib/settings/dialog.dart
+++ b/lib/settings/dialog.dart
@@ -80,6 +80,9 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
     ref.read(partitionProvider.notifier).state =
         prefs.getBool('partition') ?? ref.read(partitionProvider);
 
+    ref.read(randomSeedSettingProvider.notifier).state =
+        prefs.getInt('randomSeed') ?? ref.read(randomSeedSettingProvider);
+
     // Update "Keep in Sync" state.
 
     ref.read(keepInSyncProvider.notifier).state =
@@ -129,7 +132,7 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
     // Random seed.
 
     ref.read(randomSeedSettingProvider.notifier).state =
-        prefs.getInt('randomSeed') ?? 42;
+        prefs.getInt('randomSeed') ?? defaultRandomSeed;
 
     // Max factor.
 

--- a/lib/settings/sections/dataset_toggles.dart
+++ b/lib/settings/sections/dataset_toggles.dart
@@ -62,6 +62,7 @@ class DatasetToggles extends ConsumerWidget {
       await prefs.setBool('normalise', ref.read(normaliseProvider));
       await prefs.setBool('partition', ref.read(partitionProvider));
       await prefs.setInt('maxFactor', ref.read(maxFactorProvider));
+      await prefs.setInt('randomSeed', ref.read(randomSeedSettingProvider));
     }
 
     void _resetToggleStates() {

--- a/lib/settings/sections/random_seed.dart
+++ b/lib/settings/sections/random_seed.dart
@@ -40,7 +40,6 @@ class RandomSeed extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final randomSeed = ref.watch(randomSeedSettingProvider);
     final randomPartition = ref.watch(randomPartitionSettingProvider);
 
     Future<void> _saveRandomSeed(int value) async {
@@ -84,7 +83,6 @@ class RandomSeed extends ConsumerWidget {
             ),
             configRowGap,
             RandomSeedRow(
-              randomSeed: randomSeed,
               updateSeed: (newSeed) {
                 ref.read(randomSeedSettingProvider.notifier).state = newSeed;
                 _saveRandomSeed(newSeed);
@@ -130,8 +128,9 @@ class RandomSeed extends ConsumerWidget {
               ''',
               child: ElevatedButton(
                 onPressed: () {
-                  ref.read(randomSeedSettingProvider.notifier).state = 42;
-                  _saveRandomSeed(42);
+                  ref.read(randomSeedSettingProvider.notifier).state =
+                      defaultRandomSeed;
+                  _saveRandomSeed(defaultRandomSeed);
 
                   ref
                       .read(

--- a/lib/widgets/repeat_button.dart
+++ b/lib/widgets/repeat_button.dart
@@ -32,9 +32,11 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:markdown_tooltip/markdown_tooltip.dart';
 
 import 'package:rattle/constants/spacing.dart';
+import 'package:rattle/providers/settings.dart';
 
 class RepeatButton extends StatefulWidget {
   final Widget child;
@@ -82,18 +84,18 @@ class _RepeatButtonState extends State<RepeatButton> {
   }
 }
 
-class RandomSeedRow extends StatelessWidget {
-  final int randomSeed;
+class RandomSeedRow extends ConsumerWidget {
   final Function(int) updateSeed;
 
   const RandomSeedRow({
     Key? key,
-    required this.randomSeed,
     required this.updateSeed,
   }) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final randomSeed = ref.watch(randomSeedSettingProvider);
+
     return Row(
       children: [
         RepeatButton(


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- CLUSTER SEED: Push random seed changes back to provider/SETTINGS and disable for hiearchical

- Link to associated issue: #1028 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [x] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
