### PR TITLE
Zy/1034 toggle partition cleanup

### DIFF
--- a/lib/features/dataset/toggles.dart
+++ b/lib/features/dataset/toggles.dart
@@ -102,6 +102,12 @@ class _DatasetTogglesState extends ConsumerState<DatasetToggles> {
 
       ref.read(randomSeedSettingProvider.notifier).state =
           prefs.getInt('randomSeed') ?? defaultRandomSeed;
+
+      // Set the initial state of the "Keep in Sync" toggle based on shared preferences,
+      // defaulting to `true` if no value is found.
+
+      ref.read(keepInSyncProvider.notifier).state =
+          prefs.getBool('keepInSync') ?? true;
     } else {
       // If this is not the first start and "Keep in Sync" is enabled.
 
@@ -126,10 +132,16 @@ class _DatasetTogglesState extends ConsumerState<DatasetToggles> {
             prefs.getBool('partition') ?? ref.read(partitionProvider);
 
         // Set the initial state of the "Random Seed" toggle based on shared preferences,
-        // defaulting to [defaultRandomSeed] if no value is found.
+        // defaulting to the current provider state if no value is found.
 
         ref.read(randomSeedSettingProvider.notifier).state =
             prefs.getInt('randomSeed') ?? ref.read(randomSeedSettingProvider);
+
+        // Set the initial state of the "Keep in Sync" toggle based on shared preferences,
+        // defaulting to the current provider state if no value is found.
+
+        ref.read(keepInSyncProvider.notifier).state =
+            prefs.getBool('keepInSync') ?? ref.read(keepInSyncProvider);
       }
     }
   }

--- a/lib/providers/keep_in_sync.dart
+++ b/lib/providers/keep_in_sync.dart
@@ -25,4 +25,7 @@ library;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final keepInSyncProvider = StateProvider<bool>((ref) => false);
+// Set default value to true, the same with default value
+// in dataset setting popup window.
+
+final keepInSyncProvider = StateProvider<bool>((ref) => true);

--- a/lib/settings/dialog.dart
+++ b/lib/settings/dialog.dart
@@ -86,7 +86,7 @@ class SettingsDialogState extends ConsumerState<SettingsDialog> {
     // Update "Keep in Sync" state.
 
     ref.read(keepInSyncProvider.notifier).state =
-        prefs.getBool('keepInSync') ?? true;
+        prefs.getBool('keepInSync') ?? ref.read(keepInSyncProvider);
 
     // Update "Session Control" state.
 

--- a/lib/widgets/number_field.dart
+++ b/lib/widgets/number_field.dart
@@ -33,6 +33,7 @@ import 'package:flutter/services.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:markdown_tooltip/markdown_tooltip.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:rattle/constants/style.dart';
 
@@ -133,7 +134,7 @@ class NumberFieldState extends ConsumerState<NumberField> {
     );
   }
 
-  void increment() {
+  void increment() async {
     num currentValue = num.tryParse(widget.controller.text) ?? 0;
     currentValue += widget.interval;
 
@@ -146,9 +147,21 @@ class NumberFieldState extends ConsumerState<NumberField> {
     // Update the state provider directly.
 
     ref.read(widget.stateProvider.notifier).state = currentValue;
+
+    // This is not a nice way to handle the random seed specifically,
+    // but it's a temporary solution until we implement a more generic
+    // approach for saving field values to SharedPreferences.
+
+    if (widget.label == 'Seed:') {
+      // Update the shared preferences only for the seed field.
+
+      final prefs = await SharedPreferences.getInstance();
+
+      prefs.setInt('randomSeed', currentValue.toInt());
+    }
   }
 
-  void decrement() {
+  void decrement() async {
     num currentValue = num.tryParse(widget.controller.text) ?? 0;
     currentValue -= widget.interval;
 
@@ -161,6 +174,18 @@ class NumberFieldState extends ConsumerState<NumberField> {
     // Update state provider directly.
 
     ref.read(widget.stateProvider.notifier).state = currentValue;
+
+    // This is not a nice way to handle the random seed specifically,
+    // but it's a temporary solution until we implement a more generic
+    // approach for saving field values to SharedPreferences.
+
+    if (widget.label == 'Seed:') {
+      // Update the shared preferences only for the seed field.
+
+      final prefs = await SharedPreferences.getInstance();
+
+      prefs.setInt('randomSeed', currentValue.toInt());
+    }
   }
 
   // A timer for continuous incrementing/decrementing.


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- BUG: Seed, partition, cleanup status save after app quit.

- Link to associated issue: #1034

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [x] Windows
- [x] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
