### PR TITLE
Zy/1007 image support showing optional

### DIFF
--- a/assets/r/explore_correlation.R
+++ b/assets/r/explore_correlation.R
@@ -76,4 +76,7 @@ dev.off()
 
 svg("<TEMPDIR>/explore_correlation_ggcorrplot.svg")
 ggcorrplot::ggcorrplot(cor, method='circle')
+
+png("<TEMPDIR>/explore_correlation_ggcorrplot.png")
+ggcorrplot::ggcorrplot(cor, method='circle')
 dev.off()

--- a/assets/r/explore_correlation.R
+++ b/assets/r/explore_correlation.R
@@ -5,7 +5,7 @@
 # License: GNU General Public License, Version 3 (the "License")
 # https://www.gnu.org/licenses/gpl-3.0.en.html
 #
-# Time-stamp: <Sunday 2025-03-09 19:30:08 +1100 Graham Williams>
+# Time-stamp: <Saturday 2025-04-19 07:09:26 +1000 Graham Williams>
 #
 # Licensed under the GNU General Public License, Version 3 (the "License");
 #
@@ -76,6 +76,7 @@ dev.off()
 
 svg("<TEMPDIR>/explore_correlation_ggcorrplot.svg")
 ggcorrplot::ggcorrplot(cor, method='circle')
+dev.off()
 
 png("<TEMPDIR>/explore_correlation_ggcorrplot.png")
 ggcorrplot::ggcorrplot(cor, method='circle')

--- a/assets/r/model_build_association.R
+++ b/assets/r/model_build_association.R
@@ -5,7 +5,7 @@
 # License: GNU General Public License, Version 3 (the "License")
 # https://www.gnu.org/licenses/gpl-3.0.en.html
 #
-# Time-stamp: <Thursday 2025-04-03 17:37:47 +1100 Graham Williams>
+# Time-stamp: <Saturday 2025-04-19 07:23:12 +1000 Graham Williams>
 #
 # Licensed under the GNU General Public License, Version 3 (the "License");
 #
@@ -132,7 +132,9 @@ dev.off()
 ## be to go with PNG for
 ## now. https://github.com/dnfield/flutter_svg/issues/53
 ##
-## svg("<TEMPDIR>/model_arules_viz.svg")
+svg("<TEMPDIR>/model_arules_viz.svg")
+plot(top_rules, method="graph")
+dev.off()
 
 png("<TEMPDIR>/model_arules_viz.png")
 plot(top_rules, method="graph")

--- a/lib/features/association/display.dart
+++ b/lib/features/association/display.dart
@@ -5,7 +5,7 @@
 /// License: GNU General Public License, Version 3 (the "License")
 /// https://www.gnu.org/licenses/gpl-3.0.en.html
 //
-// Time-stamp: <Thursday 2025-04-03 17:39:31 +1100 Graham Williams>
+// Time-stamp: <Saturday 2025-04-19 07:25:46 +1000 Graham Williams>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software
@@ -172,9 +172,8 @@ class _AssociationDisplayState extends ConsumerState<AssociationDisplay> {
     // flutter_svg. https://github.com/dnfield/flutter_svg/issues/53. We display
     // the PNG version for now.
 
-    // image = '$tempDir/model_arules_viz.svg';
-
-    image = '$tempDir/model_arules_viz.png';
+    String imageSVG = '$tempDir/model_arules_viz.svg';
+    String imagePNG = '$tempDir/model_arules_viz.png';
 
     if (imageExists(image)) {
       pages.add(
@@ -187,7 +186,8 @@ class _AssociationDisplayState extends ConsumerState<AssociationDisplay> {
           [arulesViz::plot()](https://www.rdocumentation.org/packages/arulesViz/topics/plot).
 
           ''',
-          path: image,
+          path: imageSVG,
+          display: imagePNG,
         ),
       );
     }

--- a/lib/features/association/display.dart
+++ b/lib/features/association/display.dart
@@ -225,9 +225,9 @@ class _AssociationDisplayState extends ConsumerState<AssociationDisplay> {
     //
     // 20250204 gjw Even the PNG is not loading for this one.
 
-    image = '$tempDir/model_arules_grouped.svg';
+    // image = '$tempDir/model_arules_grouped.svg';
 
-    // image = '$tempDir/model_arules_grouped.png';
+    image = '$tempDir/model_arules_grouped.png';
 
     if (imageExists(image)) {
       pages.add(
@@ -244,6 +244,7 @@ class _AssociationDisplayState extends ConsumerState<AssociationDisplay> {
 
           ''',
           path: image,
+          display: image,
         ),
       );
     }

--- a/lib/features/correlation/display.dart
+++ b/lib/features/correlation/display.dart
@@ -130,6 +130,8 @@ class _CorrelationDisplayState extends ConsumerState<CorrelationDisplay> {
     // external viewer is just fine? Add a note. THe problem is the unhandled
     // element <filter/> for the Svg loader (gjw 20240815).
 
+    String ggcorrplot = '$tempDir/explore_correlation_ggcorrplot.png';
+
     pages.add(
       ImagePage(
         title: '''
@@ -143,8 +145,8 @@ class _CorrelationDisplayState extends ConsumerState<CorrelationDisplay> {
         right. Our current SVG viewer does not support all SVG features.
 
         ''',
-        path: '$tempDir/explore_correlation_ggcorrplot.svg',
-        display: '$tempDir/explore_correlation_ggcorrplot.png',
+        path: ggcorrplot,
+        display: ggcorrplot,
       ),
     );
 

--- a/lib/features/correlation/display.dart
+++ b/lib/features/correlation/display.dart
@@ -5,7 +5,7 @@
 /// License: GNU General Public License, Version 3 (the "License")
 /// https://www.gnu.org/licenses/gpl-3.0.en.html
 //
-// Time-stamp: <Thursday 2025-04-03 17:34:27 +1100 Graham Williams>
+// Time-stamp: <Saturday 2025-04-19 06:46:25 +1000 Graham Williams>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software
@@ -126,11 +126,13 @@ class _CorrelationDisplayState extends ConsumerState<CorrelationDisplay> {
     // GGCORRPLOT
     ////////////////////////////////////////////////////////////////////////
     //
-    // This only displays a black box in the app? The display of it using the
-    // external viewer is just fine? Add a note. THe problem is the unhandled
-    // element <filter/> for the Svg loader (gjw 20240815).
+    // The **svg** only displays a black box in the app. The display of it using
+    // the external viewer is just fine. The problem is the unhandled element
+    // <filter/> for the Svg loader. So we pass both the **svg** and the **png**
+    // (gjw 20250419).
 
-    String ggcorrplot = '$tempDir/explore_correlation_ggcorrplot.png';
+    String imageSVG = '$tempDir/explore_correlation_ggcorrplot.svg';
+    String imagePNG = '$tempDir/explore_correlation_ggcorrplot.png';
 
     pages.add(
       ImagePage(
@@ -145,8 +147,8 @@ class _CorrelationDisplayState extends ConsumerState<CorrelationDisplay> {
         right. Our current SVG viewer does not support all SVG features.
 
         ''',
-        path: ggcorrplot,
-        display: ggcorrplot,
+        path: imageSVG,
+        display: imagePNG,
       ),
     );
 

--- a/lib/features/correlation/display.dart
+++ b/lib/features/correlation/display.dart
@@ -144,6 +144,7 @@ class _CorrelationDisplayState extends ConsumerState<CorrelationDisplay> {
 
         ''',
         path: '$tempDir/explore_correlation_ggcorrplot.svg',
+        display: '$tempDir/explore_correlation_ggcorrplot.png',
       ),
     );
 

--- a/lib/utils/show_image_dialog.dart
+++ b/lib/utils/show_image_dialog.dart
@@ -31,8 +31,11 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_svg/flutter_svg.dart';
 
-void showImageDialog(BuildContext context, Uint8List bytes,
-    {bool isSvg = true}) {
+void showImageDialog(
+  BuildContext context,
+  Uint8List bytes, {
+  bool isSvg = true,
+}) {
   showGeneralDialog(
     context: context,
     pageBuilder: (context, animation, secondaryAnimation) {

--- a/lib/utils/show_image_dialog.dart
+++ b/lib/utils/show_image_dialog.dart
@@ -31,7 +31,8 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_svg/flutter_svg.dart';
 
-void showImageDialog(BuildContext context, Uint8List bytes) {
+void showImageDialog(BuildContext context, Uint8List bytes,
+    {bool isSvg = true}) {
   showGeneralDialog(
     context: context,
     pageBuilder: (context, animation, secondaryAnimation) {
@@ -47,7 +48,7 @@ void showImageDialog(BuildContext context, Uint8List bytes) {
                 color: Colors.white,
                 child: InteractiveViewer(
                   maxScale: 5,
-                  child: SvgPicture.memory(bytes),
+                  child: isSvg ? SvgPicture.memory(bytes) : Image.memory(bytes),
                 ),
               ),
               Positioned(

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -268,16 +268,23 @@ class ImagePage extends ConsumerWidget {
                             color: Colors.blue,
                           ),
                           onPressed: () async {
-                            // Generate a unique file name for the new file in the
-                            // temporary directory.
+                            // Determine which image to open based on display parameter.
 
+                            final displayPath = display ?? path;
+                            final bool isSvg =
+                                displayPath.toLowerCase().endsWith('.svg');
+
+                            // Generate a unique file name for the new file in the
+                            // temporary directory with the correct extension.
+
+                            String extension = isSvg ? 'svg' : 'png';
                             String fileName =
-                                'plot_${Random().nextInt(10000)}.svg';
+                                'plot_${Random().nextInt(10000)}.$extension';
                             File tempFile = File('$tempDir/$fileName');
 
                             // Copy the original file to the temporary file.
 
-                            File(path).copy(tempFile.path);
+                            await File(displayPath).copy(tempFile.path);
 
                             // Get the image viewer app from SharedPreferences or use the provider default
                             // if not set.
@@ -322,7 +329,8 @@ class ImagePage extends ConsumerWidget {
                             color: Colors.blue,
                           ),
                           onPressed: () async {
-                            String fileName = path.split('/').last;
+                            final displayPath = display ?? path;
+                            String fileName = displayPath.split('/').last;
                             String? pathToSave = await selectFile(
                               defaultFileName: fileName,
                               allowedExtensions: ['svg', 'pdf', 'png'],
@@ -331,11 +339,19 @@ class ImagePage extends ConsumerWidget {
                               String extension =
                                   pathToSave.split('.').last.toLowerCase();
                               if (extension == 'svg') {
-                                await File(path).copy(pathToSave);
+                                await File(displayPath).copy(pathToSave);
                               } else if (extension == 'pdf') {
-                                await _exportToPdf(path, pathToSave);
+                                await _exportToPdf(displayPath, pathToSave);
                               } else if (extension == 'png') {
-                                await _exportToPng(path, pathToSave);
+                                if (displayPath
+                                    .toLowerCase()
+                                    .endsWith('.svg')) {
+                                  await _exportToPng(displayPath, pathToSave);
+                                } else {
+                                  // If source is already PNG, just copy it.
+
+                                  await File(displayPath).copy(pathToSave);
+                                }
                               } else {
                                 // If the user selected an unsupported file
                                 // extension show an error dialog.

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -1,6 +1,6 @@
 /// A widget to build the a common single image based pages.
 //
-// Time-stamp: <Saturday 2025-04-19 07:10:02 +1000 Graham Williams>
+// Time-stamp: <Tuesday 2025-04-22 14:15:32 +1000 Graham Williams>
 //
 /// Copyright (C) 2024, Togaware Pty Ltd
 ///
@@ -175,11 +175,6 @@ class ImagePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Log the path being used for debugging.
-
-    debugText('  PATH', path);
-    debugText('  DISPLAY', display ?? 'NULL');
-
     // Clear the image cache.
 
     imageCache.clear();
@@ -252,9 +247,9 @@ class ImagePage extends ConsumerWidget {
                             // is provided then that overrides [path]. (gjw
                             // 20250419)
 
-                            final displayPath = display ?? path;
-                            final bool isSvg =
-                                displayPath.toLowerCase().endsWith('.svg');
+                            final bool isSvg = (display ?? path)
+                                .toLowerCase()
+                                .endsWith('.svg');
                             showImageDialog(context, bytes, isSvg: isSvg);
                           },
                         ),
@@ -279,12 +274,12 @@ class ImagePage extends ConsumerWidget {
                             color: Colors.blue,
                           ),
                           onPressed: () async {
-                            // We always display the [path] extermally
-                            // irrespective of whether we have a [display].
+                            // We always display the [path] externally,
+                            // irrespective of whether we have a [display],
+                            // which is intended for in-app use only.
 
-                            final displayPath = path;
                             final bool isSvg =
-                                displayPath.toLowerCase().endsWith('.svg');
+                                path.toLowerCase().endsWith('.svg');
 
                             // Generate a unique file name for the new file in the
                             // temporary directory with the correct extension.
@@ -296,7 +291,7 @@ class ImagePage extends ConsumerWidget {
 
                             // Copy the original file to the temporary file.
 
-                            await File(displayPath).copy(tempFile.path);
+                            await File(path).copy(tempFile.path);
 
                             // Get the image viewer app from SharedPreferences or use the provider default
                             // if not set.
@@ -341,8 +336,7 @@ class ImagePage extends ConsumerWidget {
                             color: Colors.blue,
                           ),
                           onPressed: () async {
-                            final displayPath = path;
-                            String fileName = displayPath.split('/').last;
+                            String fileName = path.split('/').last;
                             String? pathToSave = await selectFile(
                               defaultFileName: fileName,
                               allowedExtensions: ['svg', 'pdf', 'png'],
@@ -351,18 +345,16 @@ class ImagePage extends ConsumerWidget {
                               String extension =
                                   pathToSave.split('.').last.toLowerCase();
                               if (extension == 'svg') {
-                                await File(displayPath).copy(pathToSave);
+                                await File(path).copy(pathToSave);
                               } else if (extension == 'pdf') {
-                                await _exportToPdf(displayPath, pathToSave);
+                                await _exportToPdf(path, pathToSave);
                               } else if (extension == 'png') {
-                                if (displayPath
-                                    .toLowerCase()
-                                    .endsWith('.svg')) {
-                                  await _exportToPng(displayPath, pathToSave);
+                                if (path.toLowerCase().endsWith('.svg')) {
+                                  await _exportToPng(path, pathToSave);
                                 } else {
                                   // If source is already PNG, just copy it.
 
-                                  await File(displayPath).copy(pathToSave);
+                                  await File(path).copy(pathToSave);
                                 }
                               } else {
                                 // If the user selected an unsupported file
@@ -403,9 +395,8 @@ class ImagePage extends ConsumerWidget {
 
                       // Determine which image to display based on file extension.
 
-                      final String displayPath = display ?? path;
                       final bool isSvg =
-                          displayPath.toLowerCase().endsWith('.svg');
+                          (display ?? path).toLowerCase().endsWith('.svg');
 
                       return SizedBox(
                         height: maxHeight,

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -1,6 +1,6 @@
 /// A widget to build the a common single image based pages.
 //
-// Time-stamp: <Sunday 2025-03-30 07:45:33 +1100 Graham Williams>
+// Time-stamp: <Saturday 2025-04-19 07:10:02 +1000 Graham Williams>
 //
 /// Copyright (C) 2024, Togaware Pty Ltd
 ///
@@ -54,6 +54,11 @@ import 'package:rattle/utils/select_file.dart';
 import 'package:rattle/utils/show_image_dialog.dart';
 import 'package:rattle/utils/show_ok.dart';
 
+/// The [path] is required. It is the path to a **svg** or **png** file to
+/// display in the app and to open/save externally. If [display] is also
+/// provided then this will be a **png** that is displayed in the app, while the
+/// [path] is an **svg** to open/save externally.
+
 class ImagePage extends ConsumerWidget {
   final String title;
   final String path;
@@ -66,13 +71,13 @@ class ImagePage extends ConsumerWidget {
     this.display,
   });
 
-  /// Load the image bytes from the specified file path.
-  ///
-  /// This method attempts to read the image file as bytes. If using the display parameter,
-  /// it will load from that path, otherwise it uses the original SVG path.
-  ///
-  /// Returns a [Future] that completes with the image bytes as a [Uint8List] if
-  /// the file exists, or `null` if the file does not exist.
+  // Load the image bytes from the specified file path.
+  //
+  // This method attempts to read the image file as bytes. If using the display parameter,
+  // it will load from that path, otherwise it uses the original SVG path.
+  //
+  // Returns a [Future] that completes with the image bytes as a [Uint8List] if
+  // the file exists, or `null` if the file does not exist.
 
   Future<Uint8List?> _loadImageBytes() async {
     try {
@@ -106,9 +111,9 @@ class ImagePage extends ConsumerWidget {
     }
   }
 
-  /// Convert the file [svgPath] return [Future] image bytes in PNG format.
-  ///
-  /// Throws an [Exception] if the conversion fails.
+  // Convert the file [svgPath] return [Future] image bytes in PNG format.
+  //
+  // Throws an [Exception] if the conversion fails.
 
   Future<ByteData> _svgToImageBytes(String svgPath) async {
     final svgString = await File(svgPath).readAsString();
@@ -137,7 +142,7 @@ class ImagePage extends ConsumerWidget {
     return byteData;
   }
 
-  /// Export the SVG file [svgPath] into a PDF file [pdfPath].
+  // Export the SVG file [svgPath] into a PDF file [pdfPath].
 
   Future<void> _exportToPdf(String svgPath, String pdfPath) async {
     final pngBytes = await _svgToImageBytes(svgPath);
@@ -159,7 +164,7 @@ class ImagePage extends ConsumerWidget {
     await file.writeAsBytes(await pdf.save());
   }
 
-  /// Export the SVG file [svgPath] into a PNG file [pngPath].
+  // Export the SVG file [svgPath] into a PNG file [pngPath].
 
   Future<void> _exportToPng(String svgPath, String pngPath) async {
     final pngBytes = await _svgToImageBytes(svgPath);
@@ -172,9 +177,11 @@ class ImagePage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // Log the path being used for debugging.
 
-    debugText('  IMAGE', display ?? path);
+    debugText('  PATH', path);
+    debugText('  DISPLAY', display ?? 'NULL');
 
-    // Clear the image cache
+    // Clear the image cache.
+
     imageCache.clear();
     imageCache.clearLiveImages();
 
@@ -239,7 +246,9 @@ class ImagePage extends ConsumerWidget {
                             color: Colors.blue,
                           ),
                           onPressed: () {
-                            // Determine which image to display based on file extension.
+                            // Determine which image to display. If a [display]
+                            // is provided then that overrides [path]. (gjw
+                            // 20250419)
 
                             final displayPath = display ?? path;
                             final bool isSvg =
@@ -268,9 +277,10 @@ class ImagePage extends ConsumerWidget {
                             color: Colors.blue,
                           ),
                           onPressed: () async {
-                            // Determine which image to open based on display parameter.
+                            // We always display the [path] extermally
+                            // irrespective of whether we have a [display].
 
-                            final displayPath = display ?? path;
+                            final displayPath = path;
                             final bool isSvg =
                                 displayPath.toLowerCase().endsWith('.svg');
 
@@ -302,10 +312,10 @@ class ImagePage extends ConsumerWidget {
                             Platform.isWindows
                                 ? Process.run(
                                     imageViewerApp!,
-                                    [tempFile.path],
+                                    [path],
                                     runInShell: true,
                                   )
-                                : Process.run(imageViewerApp!, [tempFile.path]);
+                                : Process.run(imageViewerApp!, [path]);
                           },
                         ),
                       ),
@@ -329,7 +339,7 @@ class ImagePage extends ConsumerWidget {
                             color: Colors.blue,
                           ),
                           onPressed: () async {
-                            final displayPath = display ?? path;
+                            final displayPath = path;
                             String fileName = displayPath.split('/').last;
                             String? pathToSave = await selectFile(
                               defaultFileName: fileName,

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -1,6 +1,6 @@
 /// A widget to build the a common single image based pages.
 //
-// Time-stamp: <Tuesday 2025-04-22 14:15:32 +1000 Graham Williams>
+// Time-stamp: <Tuesday 2025-04-22 14:18:44 +1000 Graham Williams>
 //
 /// Copyright (C) 2024, Togaware Pty Ltd
 ///
@@ -49,7 +49,6 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:rattle/constants/sunken_box_decoration.dart';
 import 'package:rattle/constants/temp_dir.dart';
 import 'package:rattle/providers/settings.dart';
-import 'package:rattle/utils/debug_text.dart';
 import 'package:rattle/utils/select_file.dart';
 import 'package:rattle/utils/show_image_dialog.dart';
 import 'package:rattle/utils/show_ok.dart';

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -74,7 +74,7 @@ class ImagePage extends ConsumerWidget {
   // Load the image bytes from the specified file path.
   //
   // This method attempts to read the image file as bytes. If using the display parameter,
-  // it will load from that path, otherwise it uses the original SVG path.
+  // it will load from [display], otherwise it uses the original SVG path.
   //
   // Returns a [Future] that completes with the image bytes as a [Uint8List] if
   // the file exists, or `null` if the file does not exist.
@@ -214,6 +214,7 @@ class ImagePage extends ConsumerWidget {
                 children: [
                   Row(
                     // 20240726 gjw Ensure the Save button is aligned at the top.
+
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       // 20240726 gjw Remove the Flexible for now. Perhaps avoid
@@ -224,6 +225,7 @@ class ImagePage extends ConsumerWidget {
                       // 20240725 gjw Introduce the Flexible wrapper to avoid the markdown
                       // text overflowing to the elevarted Export
                       // button.
+
                       MarkdownBody(
                         data: wordWrap(title),
                         selectable: true,
@@ -365,6 +367,7 @@ class ImagePage extends ConsumerWidget {
                               } else {
                                 // If the user selected an unsupported file
                                 // extension show an error dialog.
+
                                 showOk(
                                   title: 'Error',
                                   context: context,

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -32,10 +32,11 @@ library;
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -56,39 +57,53 @@ import 'package:rattle/utils/show_ok.dart';
 class ImagePage extends ConsumerWidget {
   final String title;
   final String path;
+  final String? display;
 
   const ImagePage({
     super.key,
     required this.title,
     required this.path,
+    this.display,
   });
 
   /// Load the image bytes from the specified file path.
   ///
-  /// This method attempts to read the image file as bytes. It waits for the
-  /// file to exist, retrying up to 5 times with a 1-second delay between each
-  /// retry.  If the file does not exist after the retries, it returns `null`.
+  /// This method attempts to read the image file as bytes. If using the display parameter,
+  /// it will load from that path, otherwise it uses the original SVG path.
   ///
   /// Returns a [Future] that completes with the image bytes as a [Uint8List] if
   /// the file exists, or `null` if the file does not exist.
 
   Future<Uint8List?> _loadImageBytes() async {
-    var imageFile = File(path);
+    try {
+      final displayPath = display ?? path;
 
-    // Wait until the file exists, but limit the waiting period to avoid an infinite loop.
-    int retries = 5;
-    while (!await imageFile.exists() && retries > 0) {
-      await Future.delayed(const Duration(seconds: 1));
-      retries--;
-    }
+      // Wait for the file to exist.
 
-    // If the file doesn't exist, return null.
-    if (!await imageFile.exists()) {
+      final file = File(displayPath);
+      int retryCount = 0;
+      while (!await file.exists() && retryCount < 5) {
+        await Future.delayed(const Duration(seconds: 1));
+
+        retryCount++;
+      }
+
+      if (await file.exists()) {
+        return await file.readAsBytes();
+      } else {
+        if (kDebugMode) {
+          print('Image file not found: $displayPath');
+        }
+
+        return null;
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('Error loading image: $e');
+      }
+
       return null;
     }
-
-    // Read file as bytes
-    return await imageFile.readAsBytes();
   }
 
   /// Convert the file [svgPath] return [Future] image bytes in PNG format.
@@ -155,7 +170,9 @@ class ImagePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    debugText('  IMAGE', path);
+    // Log the path being used for debugging.
+
+    debugText('  IMAGE', display ?? path);
 
     // Clear the image cache
     imageCache.clear();
@@ -350,13 +367,19 @@ class ImagePage extends ConsumerWidget {
                       final double maxHeight =
                           MediaQuery.of(context).size.height * 0.6;
 
+                      // Determine which image to display based on file extension.
+
+                      final String displayPath = display ?? path;
+                      final bool isSvg =
+                          displayPath.toLowerCase().endsWith('.svg');
+
                       return SizedBox(
                         height: maxHeight,
                         width: maxWidth,
                         child: InteractiveViewer(
                           maxScale: 5,
                           alignment: Alignment.topCenter,
-                          child: path.toLowerCase().endsWith('.svg')
+                          child: isSvg
                               ? SvgPicture.memory(
                                   bytes,
                                   fit: BoxFit.scaleDown,

--- a/lib/widgets/image_page.dart
+++ b/lib/widgets/image_page.dart
@@ -239,7 +239,12 @@ class ImagePage extends ConsumerWidget {
                             color: Colors.blue,
                           ),
                           onPressed: () {
-                            showImageDialog(context, bytes);
+                            // Determine which image to display based on file extension.
+
+                            final displayPath = display ?? path;
+                            final bool isSvg =
+                                displayPath.toLowerCase().endsWith('.svg');
+                            showImageDialog(context, bytes, isSvg: isSvg);
                           },
                         ),
                       ),


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- IMAGE PAGE: Support showing an optional PNG but SVG if OPENned or SAVEd.

- Link to associated issue: #1007

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [x] Windows
- [x] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
