### PR TITLE
Zy/1048 cluster add option size pairs plot

### DIFF
--- a/assets/r/dataset_template.R
+++ b/assets/r/dataset_template.R
@@ -82,6 +82,12 @@ nobs   <- nrow(ds)
 ##
 nobs
 
+# Record the number of columns.
+
+ncolumns <- ncol(ds)
+
+ncolumns
+
 # Note the variable names.
 
 vars   <- names(ds)

--- a/assets/r/model_plot_cluster_pairs.R
+++ b/assets/r/model_plot_cluster_pairs.R
@@ -35,11 +35,38 @@
 set.seed(<RANDOM_SEED>)
 smpl <- sample(nrow(tds))
 
-# RattleV5 would keep just the first 5 variables for the plot. More
-# than 5 is visually crowded. But we now have zoom so let's try no
-# limitation.
+# Attempt to convert the input pair size setting (<CLUSTER_PAIR_SIZE>)
+# to a usable numeric value.
 
-vars <- 1:ncol(tds) # min(5, ncol(tds))
+raw_pair_size_input <- <CLUSTER_PAIR_SIZE>
+
+# Convert to numeric, suppressing warnings for non-numeric input (which becomes NA).
+# Use floor() to ensure we have an integer value if conversion is successful.
+
+pair_size_num <- suppressWarnings(floor(as.numeric(raw_pair_size_input)))
+
+# Validate the converted number:
+# 1. Check length: Must be exactly 1. This handles cases like NULL input,
+#    where as.numeric(NULL) results in numeric(0) which has length 0.
+#    It passes for valid single numbers (e.g., length(5) is 1, length(12) is 1).
+# 2. Check for NA: Must not be NA. This handles non-numeric string inputs.
+# 3. Check value: Must be at least 1 (pair size must be positive).
+
+is_valid_input <- length(pair_size_num) == 1 && !is.na(pair_size_num) && pair_size_num >= 1
+
+# Determine the final pair size using ifelse (avoids explicit if/else block):
+# - If input is valid: use the minimum of the validated input number and the
+#   total number of columns in the dataset (tds).
+# - If input is invalid (e.g., NULL, non-numeric string, zero, negative):
+#   use the total number of columns as the fallback pair size.
+
+pair_size <- ifelse(is_valid_input,min(pair_size_num, ncol(tds)), ncol(tds))
+
+# Ensure the final pair_size is not negative (important if ncol(tds) could be 0).
+
+pair_size <- max(1, pair_size)
+
+vars <- 1:pair_size
 
 # Create a title based on the model type.
 

--- a/lib/features/cluster/config.dart
+++ b/lib/features/cluster/config.dart
@@ -24,7 +24,10 @@
 
 library;
 
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -41,6 +44,7 @@ import 'package:rattle/utils/show_ok.dart';
 import 'package:rattle/widgets/activity_button.dart';
 import 'package:rattle/widgets/choice_chip_tip.dart';
 import 'package:rattle/widgets/labelled_checkbox.dart';
+import 'package:rattle/widgets/number_field.dart';
 
 /// A StatefulWidget to pass the ref across to the rSouorce.
 
@@ -82,6 +86,8 @@ class ClusterConfigState extends ConsumerState<ClusterConfig> {
       ''',
   };
 
+  final TextEditingController _pairSizeController = TextEditingController();
+
   @override
   Widget build(BuildContext context) {
     String type = ref.read(typeClusterProvider.notifier).state;
@@ -96,6 +102,7 @@ class ClusterConfigState extends ConsumerState<ClusterConfig> {
 
     String stdout = ref.watch(stdoutProvider);
     String nobs = rExtract(stdout, '> nobs').split(' ').last;
+    String ncolumns = rExtract(stdout, '> ncolumns').split(' ').last;
 
     // Convert nobs to integer if possible.
 
@@ -109,6 +116,16 @@ class ClusterConfigState extends ConsumerState<ClusterConfig> {
         }
       } catch (e) {
         // Keep nobsInt as null if parsing fails.
+      }
+    }
+
+    int? ncolumnsInt;
+    if (ncolumns.isNotEmpty) {
+      try {
+        ncolumnsInt = int.parse(ncolumns);
+        debugPrint('ncolumnsInt: $ncolumnsInt');
+      } catch (e) {
+        // Keep ncolumnsInt as null if parsing fails.
       }
     }
 
@@ -199,7 +216,6 @@ class ClusterConfigState extends ConsumerState<ClusterConfig> {
                 });
               },
             ),
-            configWidgetGap,
             LabelledCheckbox(
               key: const Key('re_scale'),
               tooltip: '''
@@ -214,6 +230,26 @@ class ClusterConfigState extends ConsumerState<ClusterConfig> {
               ''',
               label: 'Re-Scale',
               provider: reScaleClusterProvider,
+            ),
+            NumberField(
+              label: 'Pair Size:',
+              key: const Key('cluster_pair_size'),
+              tooltip: '''
+
+              **Pair Size:** Set the number of pairs to display in the pairwise
+              plot.
+
+              ''',
+              controller: _pairSizeController,
+              inputFormatter: FilteringTextInputFormatter.digitsOnly,
+              validator: (value) => validateInteger(
+                value,
+                min: defaultClusterPairSize,
+                max: (ncolumnsInt != null && ncolumnsInt > 1)
+                    ? math.max(defaultClusterPairSize, ncolumnsInt - 1)
+                    : null, // -1 for the Ident variable.
+              ),
+              stateProvider: pairSizeClusterProvider,
             ),
           ],
         ),

--- a/lib/providers/cluster.dart
+++ b/lib/providers/cluster.dart
@@ -28,10 +28,28 @@ library;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final linkClusterProvider = StateProvider<String>((ref) => 'ward');
-final numberClusterProvider = StateProvider<int>((ref) => 10);
-final processorClusterProvider = StateProvider<int>((ref) => 1);
-final reScaleClusterProvider = StateProvider<bool>((ref) => true);
-final runClusterProvider = StateProvider<int>((ref) => 1);
-final typeClusterProvider = StateProvider<String>((ref) => 'KMeans');
-final distanceClusterProvider = StateProvider<String>((ref) => 'euclidean');
+/// The default values for the parameters for cluster.
+
+const defaultClusterDistance = 'euclidean';
+const defaultClusterLink = 'ward';
+const defaultClusterNumber = 10;
+const defaultClusterPairSize = 2;
+const defaultClusterProcessor = 1;
+const defaultClusterReScale = true;
+const defaultClusterRun = 1;
+const defaultClusterType = 'KMeans';
+
+/// Providers for the parameters for cluster.
+
+final linkClusterProvider = StateProvider<String>((ref) => defaultClusterLink);
+final numberClusterProvider = StateProvider<int>((ref) => defaultClusterNumber);
+final pairSizeClusterProvider =
+    StateProvider<int>((ref) => defaultClusterPairSize);
+final processorClusterProvider =
+    StateProvider<int>((ref) => defaultClusterProcessor);
+final reScaleClusterProvider =
+    StateProvider<bool>((ref) => defaultClusterReScale);
+final runClusterProvider = StateProvider<int>((ref) => defaultClusterRun);
+final typeClusterProvider = StateProvider<String>((ref) => defaultClusterType);
+final distanceClusterProvider =
+    StateProvider<String>((ref) => defaultClusterDistance);

--- a/lib/r/source.dart
+++ b/lib/r/source.dart
@@ -236,6 +236,7 @@ Future<void> rSource(
   int clusterNum = ref.read(numberClusterProvider);
   int clusterRun = ref.read(runClusterProvider);
   int clusterProcessor = ref.read(processorClusterProvider);
+  int clusterPairSize = ref.read(pairSizeClusterProvider);
   bool clusterReScale = ref.read(reScaleClusterProvider);
   String clusterDistance = ref.read(distanceClusterProvider);
   String clusterLink = ref.read(linkClusterProvider);
@@ -598,7 +599,7 @@ Future<void> rSource(
       code.replaceAll('<CLUSTER_DISTANCE>', '"${clusterDistance.toString()}"');
   code = code.replaceAll('<CLUSTER_LINK>', '"${clusterLink.toString()}"');
   code = code.replaceAll('<CLUSTER_PROCESSOR>', clusterProcessor.toString());
-
+  code = code.replaceAll('<CLUSTER_PAIR_SIZE>', clusterPairSize.toString());
   ////////////////////////////////////////////////////////////////////////
   // EXPLORE - VISUAL - BOXPLOT
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- CLUSTER: Add option for size of pairs plot

- Link to associated issue: #1048 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
