### PR TITLE
Zy/1089 text rearrange tuning options

### DIFF
--- a/lib/features/wordcloud/config.dart
+++ b/lib/features/wordcloud/config.dart
@@ -136,19 +136,6 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
           children: [
             configBotGap,
             const Text('Cleaning Options:  '),
-            // Checkbox for random order of words in the cloud.
-
-            LabelledCheckbox(
-              key: const Key('random_order'),
-              tooltip: '''
-
-               Plot words in random order, otherwise in decreasing frequency.
-
-              ''',
-              label: 'Random Order',
-              provider: checkboxProvider,
-            ),
-
             LabelledCheckbox(
               key: const Key('stem'),
               tooltip: '''
@@ -161,7 +148,6 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
               label: 'Stem',
               provider: stemProvider,
             ),
-
             LabelledCheckbox(
               key: const Key('remove_punctuation'),
               tooltip: '''
@@ -172,7 +158,6 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
               label: 'Remove Punctuation',
               provider: punctuationProvider,
             ),
-
             LabelledCheckbox(
               key: const Key('remove_stopwords'),
               tooltip: '''
@@ -183,7 +168,6 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
               label: 'Remove Stopwords',
               provider: stopwordProvider,
             ),
-
             Expanded(
               child: MarkdownTooltip(
                 message: '''
@@ -258,6 +242,19 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
                     ),
                   ),
                 ),
+              ),
+
+              // Checkbox for random order of words in the cloud.
+
+              LabelledCheckbox(
+                key: const Key('random_order'),
+                tooltip: '''
+
+               Plot words in random order, otherwise in decreasing frequency.
+
+              ''',
+                label: 'Random Order',
+                provider: checkboxProvider,
               ),
             ],
           ),

--- a/lib/features/wordcloud/config.dart
+++ b/lib/features/wordcloud/config.dart
@@ -135,7 +135,7 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
           spacing: configWidgetSpace,
           children: [
             configBotGap,
-            const Text('Tuning Options:  '),
+            const Text('Cleaning Options:  '),
             // Checkbox for random order of words in the cloud.
 
             LabelledCheckbox(


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- TEXT: Re-arrange TUNING OPTIONS into CLEANING and TUNING OPTIONS

- Link to associated issue: #1089

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
