### PR TITLE
Zy/1103 load small corpus

### DIFF
--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -33,6 +33,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 import 'package:intl/intl.dart';
 import 'package:markdown_tooltip/markdown_tooltip.dart';
+import 'package:universal_io/io.dart';
 
 import 'package:rattle/constants/app.dart';
 import 'package:rattle/constants/markdown.dart';
@@ -107,7 +108,9 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
 
     if (path.endsWith('.txt')) {
       _addTextFilePage(stdout, pages);
-    } else if (path.endsWith('/corpus')) {
+    } else if (Directory(path).existsSync()) {
+      // Process as corpus if the path exists and is a directory.
+      
       _addCorpusPage(stdout, pages);
     } else if (path == weatherDemoFile ||
         // TODO 20250310 gjw Remo the deprecated weatherDemoFile

--- a/lib/features/dataset/display.dart
+++ b/lib/features/dataset/display.dart
@@ -110,7 +110,7 @@ class _DatasetDisplayState extends ConsumerState<DatasetDisplay> {
       _addTextFilePage(stdout, pages);
     } else if (Directory(path).existsSync()) {
       // Process as corpus if the path exists and is a directory.
-      
+
       _addCorpusPage(stdout, pages);
     } else if (path == weatherDemoFile ||
         // TODO 20250310 gjw Remo the deprecated weatherDemoFile


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- TEXT: When I load a small corpus I don't see the SUMMARY page under DATASET

- Link to associated issue: #1103

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [x] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
